### PR TITLE
Fix: validate dynamically-appended tools against the live schema set

### DIFF
--- a/src/chad/agent.py
+++ b/src/chad/agent.py
@@ -136,6 +136,25 @@ def _has_open_tool_call(text: str) -> bool:
             or text.count("<function=") > text.count("</function>"))
 
 
+def reject_escalation(name: str) -> str:
+    """Extra guidance appended when the SAME tool call has been rejected identically
+    back-to-back. The plain repair message clearly is not landing — the model can't see
+    the fix (or the call genuinely can't succeed as written), so re-emitting it verbatim
+    just burns turns. Break the loop: stop repeating, and — critically — do NOT fabricate
+    the result the tool would have returned. A silently-failed `activate_skill` that the
+    model papers over by reciting a skill from memory is the worst outcome: confident
+    output that never loaded the real instructions."""
+    extra = ("\n[you have now emitted this exact call twice and it was rejected both "
+             "times — re-emitting it unchanged will not work. Either change the flagged "
+             "field(s), or use a DIFFERENT tool. Do NOT invent or guess the output this "
+             "tool would have returned.]")
+    if name == "activate_skill":
+        extra += ("\n[the skill was NOT loaded. Do not proceed from memory or fabricate "
+                  "its steps. Check the exact skill `name` against the '# Skills' list, or "
+                  "continue the task with the normal read/grep/bash tools instead.]")
+    return extra
+
+
 def close_unclosed_think(text: str, thinking: bool) -> str:
     """Close a dangling `<think>` block so the stored assistant turn re-tokenizes into
     a prefix of the live KV cache.
@@ -504,6 +523,8 @@ class Agent:
         recent_sigs = []  # forge-style loop guard: detect repeated identical tool calls
         self._loop_nudges = 0
         self._validate_fails = 0  # typia self-repair rounds this turn (telemetry)
+        self._last_reject_sig = None  # (name,args) of the last validation-rejected call
+        self._reject_repeats = 0      # consecutive identical rejections (loop breaker)
         unverified_edit = False  # files changed but not run/tested since
         verify_nudges = 0
         did_work = False  # a substantive tool (not plan/done) ran this turn
@@ -869,6 +890,21 @@ class Agent:
                 if reject is not None:
                     result = reject
                     self._validate_fails += 1
+                    # Loop breaker (plan): the same call rejected identically back-to-back
+                    # means the repair message isn't landing (the model can't see the fix,
+                    # or the call can't succeed as written). Escalate — tell it to stop
+                    # re-emitting and to NOT fabricate the tool's result — instead of
+                    # letting it flail. Signature is over (name, args) so a *different*
+                    # attempt at the same tool resets the counter.
+                    rej_sig = guardrails.loop_signature([(name, args)])
+                    if rej_sig == self._last_reject_sig:
+                        self._reject_repeats += 1
+                    else:
+                        self._last_reject_sig, self._reject_repeats = rej_sig, 0
+                    if self._reject_repeats >= 1:  # 2nd identical rejection
+                        result += reject_escalation(name)
+                        log.info("VALIDATE %s rejected identically %dx -> escalate",
+                                 name, self._reject_repeats + 1)
                     log.info("VALIDATE %s rejected (%d): %s", name, self._validate_fails, detail)
                     render_tool_result(self._emit, name, args, result)
                     self.messages.append({"role": "tool", "name": name, "content": result})

--- a/src/chad/validate.py
+++ b/src/chad/validate.py
@@ -29,7 +29,7 @@ import re
 from typing import Any, List, Optional, Tuple
 
 from . import config
-from .tools import SCHEMAS
+from .tools import active_schemas
 
 # A/B knob (mirrors CHAD_NO_SYMBOLS), the single source of truth for both the
 # typed-validate path here and the lenient tool-call parse in toolcall_parse.py.
@@ -39,31 +39,32 @@ from .tools import SCHEMAS
 # exactly what the validation harness buys, per model.
 VALIDATE = not config.flag("CHAD_NO_VALIDATE")
 
-# Per-tool `parameters` schema, keyed by tool name. Single source of truth with
-# what the model is shown.
-PARAM_SCHEMAS = {
-    s["function"]["name"]: s["function"].get("parameters", {"type": "object"})
-    for s in SCHEMAS
-}
-
-
 def _param_schema(name):
-    """The `parameters` JSON-Schema for a tool — chad's builtins first, then any
-    connected MCP server's tool. None if the name is unknown. Single source of truth
-    with what the model is shown (no schema duplication for either kind)."""
-    schema = PARAM_SCHEMAS.get(name)
-    if schema is not None:
-        return schema
+    """The `parameters` JSON-Schema for a tool as it is exposed to the model RIGHT NOW —
+    chad's builtins plus every dynamically-appended tool (`activate_skill` when skills are
+    installed, `task`, and any connected MCP server's tool). None if the name is not
+    currently callable.
+
+    This reads the LIVE `active_schemas()` set rather than a frozen import-time snapshot.
+    The snapshot was the bug: dynamic tools like `activate_skill` are appended by
+    `active_schemas()` (so the model sees them) but were absent from the frozen table, so a
+    perfectly valid `activate_skill` call validated as an "unknown tool" — while the same
+    error listed it as available (`_known_tools` reads the dispatch table, which *does*
+    contain it). Sourcing both from `active_schemas()` guarantees the validation contract
+    can never drift from what the model is shown."""
+    for s in active_schemas():
+        if s["function"]["name"] == name:
+            return s["function"].get("parameters", {"type": "object"})
     from . import mcp
     return mcp.param_schema(name)
 
 
 def _known_tools():
-    """All currently-callable tool names (builtins + connected MCP tools), for the
-    'available tools' hint in unknown-tool repair messages."""
-    from . import mcp
-    from .tools import DISPATCH
-    return list(DISPATCH) + mcp.service().tool_names()
+    """All currently-callable tool names, for the 'available tools' hint in unknown-tool
+    repair messages. Sourced from the same live `active_schemas()` set as `_param_schema`
+    so the hint can never advertise a name the validator would then reject (the exact
+    inconsistency that produced 'unknown tool X ... Available: ...X...')."""
+    return [s["function"]["name"] for s in active_schemas()]
 
 
 def legacy_validate(name, args):

--- a/tests/test_agent_guards.py
+++ b/tests/test_agent_guards.py
@@ -431,7 +431,36 @@ def test_progress_note():
           "nothing" in empty.lower() or "no edits" in empty.lower(), empty)
 
 
+def test_reject_escalation():
+    # Loop breaker: appended when the SAME call is rejected twice back-to-back. Must tell
+    # the model to stop re-emitting AND forbid fabricating the tool's result.
+    from chad.agent import reject_escalation
+    generic = reject_escalation("read")
+    check("escalation says stop repeating", "twice" in generic and "not work" in generic,
+          generic)
+    check("escalation forbids fabricating output",
+          "Do NOT invent" in generic or "not invent" in generic.lower(), generic)
+    # activate_skill gets the extra anti-confabulation clause — the trace's failure mode.
+    sk = reject_escalation("activate_skill")
+    check("skill escalation says skill NOT loaded", "NOT loaded" in sk, sk)
+    check("skill escalation forbids proceeding from memory",
+          "from memory" in sk or "fabricate" in sk, sk)
+
+
+def test_reject_loop_signature_resets_on_change():
+    # The rejection loop breaker keys on (name, args): a *different* attempt at the same
+    # tool must reset the counter (it's a new try, not a repeat), while an identical
+    # re-emit matches.
+    a = loop_signature([("activate_skill", {"name": "widgets"})])
+    b = loop_signature([("activate_skill", {"name": "widgets"})])
+    c = loop_signature([("activate_skill", {"name": "gadgets"})])
+    check("identical rejected call -> same sig", a == b, (a, b))
+    check("changed arg -> different sig (counter resets)", a != c, (a, c))
+
+
 if __name__ == "__main__":
+    test_reject_escalation()
+    test_reject_loop_signature_resets_on_change()
     test_bash_result_verifies()
     test_done_rejection()
     test_update_work_flags()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -7,7 +7,16 @@ field-level error — never silently drops or silently dispatches garbage.
 Run: `uv run python test_validate.py`
 """
 
-from chad.validate import coerce_and_validate, legacy_validate, render_repair, repair_json
+import os
+
+from chad import skills
+from chad.validate import (
+    _param_schema,
+    coerce_and_validate,
+    legacy_validate,
+    render_repair,
+    repair_json,
+)
 
 PASS = 0
 FAIL = 0
@@ -119,6 +128,61 @@ def test_legacy_validate():
           "missing required argument" in miss and "path" in miss, f"msg={miss!r}")
     check("legacy: valid args pass (None)",
           legacy_validate("read", {"path": "a.py"}) is None)
+
+
+# --- Dynamically-appended tools validate against the LIVE schema set ----------
+# Regression: `activate_skill` is appended to what the model sees by
+# tools.active_schemas() only when skills are installed. The validator used to read a
+# frozen import-time snapshot that never contained it, so a valid activate_skill call
+# validated as an "unknown tool" — while the same error listed it as available. An
+# unwinnable loop: no retry could pass. This asserts the validator now tracks the live
+# set, and that the enum guard (constraining `name` to real skills) actually reaches it.
+def test_dynamic_tool_validates(tmp_path, monkeypatch):
+    empty_home = tmp_path / "_home"
+    empty_home.mkdir()
+    monkeypatch.setattr(os.path, "expanduser",
+                        lambda p: str(empty_home) if p == "~" or p.startswith("~/") else p)
+    proj = tmp_path / "proj"
+    (proj / ".agents" / "skills" / "widgets").mkdir(parents=True)
+    (proj / ".agents" / "skills" / "widgets" / "SKILL.md").write_text(
+        "---\nname: widgets\ndescription: Use when the user mentions widgets.\n---\n# Do it\n")
+    monkeypatch.chdir(proj)
+    skills.reset_session()
+    try:
+        # activate_skill is now a known tool with a real param schema...
+        sch = _param_schema("activate_skill")
+        check("activate_skill has a live param schema", sch is not None, sch)
+        check("enum constrained to installed skills",
+              sch["properties"]["name"]["enum"] == ["widgets"], sch)
+        # ...so a valid call validates cleanly (the exact call the trace could never land).
+        _, e = coerce_and_validate("activate_skill", {"name": "widgets"})
+        check("valid activate_skill accepted (no errors)", e == [], [str(x) for x in e])
+        # ...and a hallucinated skill name is rejected by the enum, not silently dispatched.
+        _, e2 = coerce_and_validate("activate_skill", {"name": "nope"})
+        check("unknown skill name rejected via enum", bool(e2), [str(x) for x in e2])
+        # The 'available tools' hint lists it (mirror source), so no contradictory message.
+        msg = render_repair("frobnicate", {}, coerce_and_validate("frobnicate", {})[1])
+        check("repair hint lists the live activate_skill", "activate_skill" in msg, msg)
+    finally:
+        skills.reset_session()
+
+
+def test_dynamic_tool_absent_without_skills(tmp_path, monkeypatch):
+    # With no skills installed, activate_skill is NOT exposed to the model, so the
+    # validator must treat it as unknown (symmetry: the hint won't list it either).
+    empty_home = tmp_path / "_home"
+    empty_home.mkdir()
+    monkeypatch.setattr(os.path, "expanduser",
+                        lambda p: str(empty_home) if p == "~" or p.startswith("~/") else p)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    skills.reset_session()
+    try:
+        check("activate_skill unknown when no skills installed",
+              _param_schema("activate_skill") is None)
+    finally:
+        skills.reset_session()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
activate_skill is appended to what the model sees by tools.active_schemas() only when skills are installed. The validator read a frozen import-time snapshot (PARAM_SCHEMAS) that never contained it, so a valid activate_skill call validated as an "unknown tool" -- while the same error listed it as available (the hint reads the dispatch table, which *does* contain it). An unwinnable loop: no retry could ever pass, and the model fell back to reciting the skill from memory as if it had loaded it.

- validate._param_schema / _known_tools now read the live active_schemas() set, so the validation contract can't drift from what the model is shown. This also revives the enum guard constraining activate_skill's `name` to real installed skills.
- agent.py: loop breaker on consecutive identical validation rejections -- on the 2nd, escalate (stop re-emitting, switch tools) and forbid fabricating the tool's result; extra anti-confabulation clause for activate_skill.
- Tests: activate_skill validates with a fake skill installed, enum reaches the validator, hallucinated names rejected, absent without skills; plus escalation-text and signature-reset coverage.