### PR TITLE
think budget throttle, not switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 Notable, user-visible changes.
 
+## [1.0.2] — 2026-07-20
+
+Reliability tuning for long, budgeted tasks, plus one interactive papercut fix.
+
+- **Syntax gate no longer flags prose & data files.** Plain-text deliverables — a
+  `.txt` answer file, `requirements.txt`, markdown, CSV/TSV — were being run through a
+  tree-sitter grammar (the language pack maps `.txt` → VIMDOC) and warned on, sometimes
+  reverted, at exactly the write that produced the deliverable. The gate now polices
+  code languages only; prose/data formats are skipped uniformly across warn, edit-revert,
+  and write-reject.
+- **`run`-style tasks no longer bail with prose.** System-state asks ("start the
+  service", "boot the image", "install X") are completable with zero file edits, and
+  used to fall through to the weakest completion path — a give-up in prose could ship
+  nothing (qemu-startup did, with most of the wall unspent). They now get their own
+  intent class that arms the anti-bail nudges, while still completing cleanly with zero
+  edits (the no-empty-diff "done" gate only ever applied to edit tasks).
+- **Reasoning budget throttles instead of muting.** Once a turn's cumulative
+  reasoning-token budget is spent, chad now forces one no-think action step per ~3k
+  further reasoning tokens (a duty cycle) rather than muting thinking for the rest of the
+  turn — thinking is restored as soon as the model stops over-spending, avoiding the
+  garbled tool-call tails a blanket mute produced.
+- **Wall-aware auto-continue.** When most of a task's wall budget is still unspent, an
+  exhausted turn is granted a fresh relaunch (bounded), instead of giving up after a
+  fixed two attempts with the clock barely touched.
+- **Rejected "done" no longer poisons the relaunch.** When a completion claim is
+  rejected for landing no verified change, the carried-forward progress note now leads
+  with a warning that the claim was rejected and drops any hypothesis that itself asserts
+  completion — so a relaunch stops inheriting "already complete and verified" as fact and
+  re-confirming it.
+
 ## [1.0.1] — 2026-07-19
 
 First complete release: a single-user coding agent that runs **entirely locally on

--- a/benchmarks/tb2/run_tb21_submit.sh
+++ b/benchmarks/tb2/run_tb21_submit.sh
@@ -30,8 +30,10 @@
 #   CHAD_BACKEND      llama                     (default llama — thelio Q6_K)
 #   CHAD_TOKENIZER    HF repo for the tokenizer (default the Q6 MLX repo; Ornith's
 #                     vocab is quant-invariant so it matches every Ornith artifact)
-#   CHAD_MODEL_LABEL  harbor -m id — becomes the submission's model id, so name
-#                     the artifact actually served
+#   CHAD_MODEL_LABEL  harbor -m id — the submission's DISPLAYED model id (default
+#                     Ornith-1.0-35B-Q6_K, a bare model name — the agent column
+#                     already carries org=chad; cosmetic for --backend llama, no
+#                     weights load from it)
 #   CHAD_TB2_TEMP     sampling temperature (default 1.0, the reference recipe)
 #   TB21_NO_UPLOAD=1  skip --upload --public (local compliance dry-runs only —
 #                     a real submission run MUST upload)
@@ -43,8 +45,12 @@ export PYTHONPATH="$PWD"
 
 BASE_URL="${CHAD_BASE_URL:?set CHAD_BASE_URL to your model server as reachable from inside Docker}"
 BACKEND="${CHAD_BACKEND:-llama}"
+# Tokenizer stays the real MLX HF repo (nathansutton/…) — it's snapshot_download'd
+# into the upload, so it must resolve; its vocab is quant-invariant. MODEL_LABEL is
+# purely the leaderboard-displayed model id (cosmetic for --backend llama), so it reads
+# org=chad, model=Ornith rather than surfacing the personal HF namespace as the "org".
 TOKENIZER="${CHAD_TOKENIZER:-nathansutton/Ornith-1.0-35B-Q6-MLX}"
-MODEL_LABEL="${CHAD_MODEL_LABEL:-mlx/nathansutton/Ornith-1.0-35B-Q6-MLX}"
+MODEL_LABEL="${CHAD_MODEL_LABEL:-Ornith-1.0-35B-Q6_K}"
 TEMP="${CHAD_TB2_TEMP:-1.0}"
 REPEATS="${1:-5}"; ONLY="${2:-}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # import name, and command name are independent. `uvx chad-code` runs the alias
 # script added under [project.scripts].
 name = "chad-code"
-version = "1.0.1"
+version = "1.0.2"
 description = "Local MLX-backed, Claude-Code-style coding agent (Apple Silicon, Ornith 35B/9B)"
 readme = "README.md"
 license = "MIT"

--- a/src/chad/__init__.py
+++ b/src/chad/__init__.py
@@ -4,4 +4,4 @@ A flat collection of cooperating modules behind one console script (``chad``):
 the inference engine, the tool layer, the agent loop, and the terminal UI.
 """
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/src/chad/agent.py
+++ b/src/chad/agent.py
@@ -807,12 +807,18 @@ class Agent:
         # Turn-level cumulative think budget: distinct from self.think_tokens
         # (lifetime across the whole Agent instance, used for cross-turn telemetry) — this
         # is THIS turn's spend, reset every run_turn call, checked against a wall- and
-        # decode-speed-aware budget. turn_think_exhausted is a PERSISTENT latch (unlike
-        # capped_stall_streak's one-shot no_think_next above): once it fires, every
-        # remaining step in the turn decodes with thinking off.
+        # decode-speed-aware budget. turn_think_exhausted latches the once-only
+        # log/steer; past it, no-think steps are paid on a duty cycle
+        # (guardrails.turn_think_throttle) rather than muting the rest of the turn —
+        # the blanket mute regressed run1 passes with garbled no-think tails (plan 107).
+        # landing_no_think is the 103 landing's own unconditional latch: once the hard
+        # wrap-up fires, the landing and everything after it stay no-think regardless.
         turn_think_tokens = 0
         turn_think_half_fired = False
         turn_think_exhausted = False
+        turn_think_nothink_paid = 0
+        turn_think_budget_now = 0
+        landing_no_think = False
         # Runaway-turn governor state. turn_start drives the optional wall
         # budget; gov_band is the highest budget checkpoint already evaluated; gov_progress
         # tracks whether a change landed+verified within the CURRENT band (resets each time
@@ -845,6 +851,12 @@ class Agent:
         # where it also selects the plan-mode prefix.)
         action_task = self.mode != "plan" and _intent["action"]
         read_only_intent = _intent["read_only"]
+        # Run-task intent (start/boot/serve/… — system-state imperatives with no file
+        # deliverable): arms the anti-bail nudges alongside action_task but is kept OUT
+        # of the no-empty-diff done gates below, which demand a landed edit a run task
+        # legitimately never makes (plan 107 follow-up: qemu-startup classified as
+        # neither, so a prose give-up with 81% of the wall left took the weakest path).
+        run_task = self.mode != "plan" and _intent.get("run", False)
         # Progress-aware step cap (see guardrails.extend_step_cap): max_steps is the
         # WINDOW size, not a hard kill. A window that landed+verified a change earns
         # another window (warm cache — no re-prefill, unlike a governor rollover); a
@@ -963,9 +975,19 @@ class Agent:
             # <think> off so the model must act, then the flag clears and thinking restores.
             # Consumes the one-shot here; the render/decode/accounting below all key off
             # `step_thinking` rather than self.thinking for exactly this step.
-            # Turn-level think budget: once exhausted, thinking stays off for
-            # every remaining step — a persistent override, unlike no_think_next below.
-            step_thinking = self.thinking and not turn_think_exhausted
+            # Turn-level think budget: past exhaustion, forced no-think steps are
+            # paid on a duty cycle (one per TURN_THINK_REARM_TOK further think tokens)
+            # so thinking RESTORES once the model stops over-spending — a blanket
+            # rest-of-turn mute regressed run1 passes (plan 107 F1). The 103 landing's
+            # landing_no_think stays unconditional.
+            _tt_throttled = (turn_think_exhausted
+                             and guardrails.turn_think_throttle(
+                                 turn_think_tokens, turn_think_budget_now,
+                                 turn_think_nothink_paid))
+            if _tt_throttled:
+                turn_think_nothink_paid += 1
+            step_thinking = (self.thinking and not landing_no_think
+                             and not _tt_throttled)
             if no_think_next:
                 no_think_next = False
                 capped_stall_streak = 0
@@ -1203,9 +1225,15 @@ class Agent:
             # turns (a Q&A turn shouldn't be pushed to "act now") and without a configured
             # wall budget (interactive/unmetered runs, like wrapup_window above).
             turn_think_tokens += _think_delta
-            if (self._turn_budget_s and self.mode != "plan" and not read_only_intent
+            # Inert below TURN_THINK_MIN_WALL_S: a short auto-continue tail clamps to
+            # the LO budget and half-fires on its first step, churning against
+            # hard_wrapup's landing (plan 107 F2 — the regex-log relaunch signature).
+            if (self._turn_budget_s
+                    and self._turn_budget_s >= guardrails.TURN_THINK_MIN_WALL_S
+                    and self.mode != "plan" and not read_only_intent
                     and levers.enabled("turn_think_budget")):
                 _tt_budget = guardrails.turn_think_budget(self._turn_budget_s, self.tok_per_s)
+                turn_think_budget_now = _tt_budget
                 _tt_decision, turn_think_half_fired, turn_think_exhausted = (
                     guardrails.turn_think_budget_check(
                         turn_think_tokens, _tt_budget,
@@ -1217,10 +1245,11 @@ class Agent:
                                           "content": guardrails.TURN_THINK_BUDGET_STEER})
                 elif _tt_decision == "exhausted":
                     log.info("THINK-BUDGET exhausted at step %d: %d/%d cumulative think "
-                             "tok this turn — no-think for the rest of the turn", step,
-                             turn_think_tokens, _tt_budget)
+                             "tok this turn — throttling <think> (one action step per "
+                             "%d further think tok)", step, turn_think_tokens,
+                             _tt_budget, guardrails.TURN_THINK_REARM_TOK)
                     self._emit("info", "  [reasoning budget exhausted for this turn — "
-                                       "acting without further <think> for the rest of it]")
+                                       "throttling further <think>]")
 
             log.info("step %d: %d tok @ %.1f tok/s | prefill %d new + %d cached | "
                      "accept %.2f", step, stats.generated_tokens, stats.tok_per_s,
@@ -1277,7 +1306,7 @@ class Agent:
             # above) with its tokens in the KV cache. Force ONE time-boxed, no-think
             # landing turn so the model writes its best artifacts to the exact paths before
             # the harness kills the turn at the wall — instead of dying mid-token with
-            # nothing landed. turn_think_exhausted makes the landing (and any step after it)
+            # nothing landed. landing_no_think makes the landing (and any step after it)
             # no-think so it can't re-open a spiral; the latch disarms _deadline_stop, so
             # the landing generation runs to its token box, not another abort. deadline_fired
             # is exclusive with rep_fired / the think-cap below (it is checked first in
@@ -1286,7 +1315,7 @@ class Agent:
             # there is rarely one, and partial-tool-call surgery is not worth its risk here.
             if deadline_fired[0] and not hard_wrapup_fired:
                 hard_wrapup_fired = True
-                turn_think_exhausted = True
+                landing_no_think = True
                 _remaining = self._turn_budget_s - (time.monotonic() - turn_start)
                 log.info("HARD-WRAPUP abort at step %d: %.0fs left, gen was %d tok",
                          step, _remaining, stats.generated_tokens)
@@ -1374,8 +1403,8 @@ class Agent:
                            or "<function=" in _stripped_for_markers)
                 kind, nudge = guardrails.nudge_for_no_calls(
                     text, hit_cap, made_edit, unverified_edit, read_only_intent,
-                    action_task, truncation_nudges, answer_nudges, verify_nudges,
-                    _has_open_tool_call(text), garbled_call=garbled)
+                    action_task or run_task, truncation_nudges, answer_nudges,
+                    verify_nudges, _has_open_tool_call(text), garbled_call=garbled)
                 if kind == "truncated":
                     truncation_nudges += 1
                 elif kind == "no-edit":
@@ -1384,7 +1413,8 @@ class Agent:
                     verify_nudges += 1
                 if nudge:
                     log.info("END-ANSWER rejected step %d: %s (hit_cap=%s, has_code=%s, "
-                             "action_task=%s)", step, kind, hit_cap, has_code, action_task)
+                             "action_task=%s, run_task=%s)", step, kind, hit_cap,
+                             has_code, action_task, run_task)
                     self.messages.append({"role": "tool", "name": "edit", "content": nudge})
                     continue
                 # Iter-3 did-nothing gate: in auto/headless mode (every benchmark run), a
@@ -1405,7 +1435,9 @@ class Agent:
                     # and end as a hard stop, so --auto-continue (headless) or the
                     # user's 'continue' (TUI) relaunches a fresh attempt with the
                     # note instead of silently shipping nothing.
-                    self.budget_note = guardrails.progress_note(self.messages)
+                    self.budget_note = guardrails.progress_note(
+                        self.messages,
+                        rejected_claim=strip_think(text).strip())
                     log.info("END step %d: FINAL ANSWER blocked by no-empty-diff gate "
                              "(made_edit=%s, unverified_edit=%s) — progress note banked",
                              step, made_edit, unverified_edit)
@@ -1497,7 +1529,9 @@ class Agent:
                     # nudges ran out) becomes a resumable hard stop, not a success
                     # (matplotlib-25332 r3: done accepted at 84s with edits in tree
                     # and zero successful post-edit commands).
-                    self.budget_note = guardrails.progress_note(self.messages)
+                    self.budget_note = guardrails.progress_note(
+                        self.messages,
+                        rejected_claim=str(terminal.get("summary") or ""))
                     log.info("END step %d: DONE blocked by no-empty-diff gate "
                              "(made_edit=%s, unverified_edit=%s) — progress note banked",
                              step, made_edit, unverified_edit)

--- a/src/chad/cli.py
+++ b/src/chad/cli.py
@@ -637,9 +637,24 @@ def main():
         # ships as an empty diff (the NIGHT-7 bail signature).
         continues = args.auto_continue if args.auto_continue is not None \
             else (2 if run_mode == "auto" else 0)
-        while agent.budget_note and continues > 0:
+        used_continues = 0
+        while agent.budget_note:
+            # Base allowance first; past it, keep granting fresh attempts while most
+            # of the task wall is still unspent (bounded by AUTO_CONTINUE_TOTAL_CAP) —
+            # the fixed base is wall-blind: build-pov-ray (TB2.1 v1.0.0) gave up after
+            # 3 step-capped turns with 94.7% of a 12000s budget unused (plan 107 F3).
+            if continues > 0:
+                continues -= 1
+            elif (args.auto_continue is None and args.turn_budget_s
+                    and guardrails.replenish_continue(
+                        args.turn_budget_s, time.monotonic() - task_start,
+                        used_continues)):
+                sys.stderr.write("[governor] wall budget mostly unspent — granting an "
+                                 "extra continue\n")
+            else:
+                break
+            used_continues += 1
             note = agent.budget_note
-            continues -= 1
             # The wall budget is a TASK-level deadline (the harness SIGKILLs the whole chad
             # process), not a per-turn one: a relaunch must inherit only the wall time that
             # REMAINS, or the governor / wrap-up / hard-abort windows (measured from each

--- a/src/chad/guardrails.py
+++ b/src/chad/guardrails.py
@@ -924,7 +924,21 @@ PROGRESS_NOTE_HEADER = (
     "Progress so far (auto-summarized — the previous attempt ran out of budget):")
 
 
-def progress_note(messages, max_lines: int = 24) -> str:
+# Matches a hypothesis that ASSERTS the work is already finished (the poison a
+# rejected-done relaunch must not inherit as its leading "fact"), NOT a diagnosis that
+# merely contains a success-ish word. Every completion word is anchored to a subject or
+# to "already": a bare `build\s+is\s` matched "reBUILD IS failing", and a standalone
+# `verified`/`successful` matched "SUCCESSFULLY reproduced the crash" — both real
+# diagnoses, dropped on the exact path meant to preserve them (eng-review outside-voice
+# F1). \b on the subjects also stops "build" from matching inside "rebuild".
+_COMPLETION_CLAIM_RE = re.compile(
+    r"(already\s+(?:built|complete|done|installed|present|correct|verified|passe?[sd])"
+    r"|\b(?:build|task|project|everything|it)\s+is\s+"
+    r"(?:complete|done|built|ready|correct|passing)"
+    r"|task\s+is\s+(?:done|complete))", re.IGNORECASE)
+
+
+def progress_note(messages, max_lines: int = 24, rejected_claim: str | None = None) -> str:
     """Synthesize a ≤`max_lines` progress note from the transcript with NO model call, so
     a hard-stopped turn can seed a fresh relaunch (sheds the ramble AND the huge prefill
     the stuck model was dragging around). Deterministic: pulls the model's last working
@@ -933,7 +947,15 @@ def progress_note(messages, max_lines: int = 24) -> str:
     facts the executor CANNOT reconstruct from a clean context — the diagnosis it reached,
     what it already tried, and what failed last. The old note carried only file names, so
     a relaunch re-derived the whole investigation and re-spent the budget it was meant to
-    save (django-14007/-14404: the correct fix was stated in prose, then lost)."""
+    save (django-14007/-14404: the correct fix was stated in prose, then lost).
+
+    `rejected_claim` (plan 107 follow-up — the build-pov-ray poisoning loop): when the
+    turn ended via a REJECTED completion claim (done / final answer blocked by the
+    no-empty-diff gate), pass the claim text. The note then (a) leads with an explicit
+    warning that the claim was rejected, and (b) drops a working hypothesis that itself
+    asserts completion — otherwise every fresh relaunch inherits "the build is already
+    complete and verified" as its leading fact, re-confirms it, and re-dones (observed
+    6 relaunches in a row, task 0/1 with 86% of the wall unused)."""
     from .toolcall_parse import parse_tool_calls
     edited, commands, examined = [], [], []
     last_error = None
@@ -968,6 +990,17 @@ def progress_note(messages, max_lines: int = 24) -> str:
     # lever adds, and therefore what its delta measures.
     rich = levers.enabled("progress_note_rich")
     lines = [PROGRESS_NOTE_HEADER]
+    if rejected_claim:
+        lines.append(
+            "WARNING: the previous attempt ended by CLAIMING the task was complete "
+            f"(\"{rejected_claim.strip()[:160]}\") but the claim was REJECTED — it had "
+            "landed no verified change. Treat every success statement below as "
+            "unverified and likely wrong: re-verify against the task statement with "
+            "fresh commands and MAKE the required change before calling done.")
+        # A hypothesis that itself asserts completion is exactly the poison the
+        # warning exists for — never carry it forward as the leading "fact".
+        if hypothesis and _COMPLETION_CLAIM_RE.search(hypothesis):
+            hypothesis = None
     if rich and hypothesis:
         # The single most valuable thing to carry: the diagnosis the stuck attempt
         # reached. Keep the tail (the conclusion), clipped so it can't blow the budget.
@@ -1088,6 +1121,28 @@ def relaunch_budget(total_wall_s, task_elapsed_s) -> float | None:
     return remaining
 
 
+AUTO_CONTINUE_TOTAL_CAP = 6       # absolute relaunch ceiling per task (base + extras)
+AUTO_CONTINUE_REPLENISH_FRAC = 0.5  # grant extras only while this fraction of the task
+                                    # wall is still unspent
+
+
+def replenish_continue(total_wall_s, elapsed_s, used_continues,
+                       cap: int = AUTO_CONTINUE_TOTAL_CAP,
+                       frac: float = AUTO_CONTINUE_REPLENISH_FRAC) -> bool:
+    """Grant an auto-continue relaunch beyond the base allowance? The fixed base of 2
+    is wall-blind: build-pov-ray (TB2.1 v1.0.0 run) burned 3 step-capped turns in 637s
+    and gave up with 94.7% of a 12000s budget unused (plan 107 F3). While more than
+    `frac` of the task wall remains unspent, keep granting fresh attempts, bounded by
+    `cap` total relaunches so a pathological fast-stall loop still terminates well
+    before the harness SIGKILL. No wall budget -> never (interactive runs keep the
+    explicit base allowance only). Pure/testable; the caller counts usage."""
+    if not total_wall_s:
+        return False
+    if used_continues >= cap:
+        return False
+    return (total_wall_s - elapsed_s) > frac * total_wall_s
+
+
 def hard_wrapup_deadline(wall_budget_s, already_fired, plan_mode, read_only) -> float | None:
     """Should the hard wrap-up abort ARM for this step? Returns the land_margin (seconds
     before the wall at which to cut the generation) when it should, else None. Lever-gated
@@ -1116,6 +1171,12 @@ TURN_THINK_BUDGET_LO = 8000    # floor: a *turn* budget, not a per-generation on
                                # must clear passes' own median spend (10.7k) comfortably
 TURN_THINK_BUDGET_HI = 24000   # ceiling: clamp regardless of wall/decode-speed inputs
 TURN_THINK_BUDGET_FRAC = 0.35  # the budget's TIME cost should stay <= ~35% of the wall
+TURN_THINK_MIN_WALL_S = 300.0  # below this wall budget the mechanism is inert: a short
+                               # auto-continue tail clamps to LO and half-fires on its
+                               # first step, churning against hard_wrapup's landing
+                               # (plan 107 F2 — the regex-log relaunch signature)
+TURN_THINK_REARM_TOK = 3000    # past exhaustion, one forced no-think step is owed per
+                               # this many FURTHER think tokens spent (plan 107 F1)
 
 
 def turn_think_budget(wall_budget_s, decode_tps, frac: float = TURN_THINK_BUDGET_FRAC,
@@ -1139,12 +1200,12 @@ TURN_THINK_BUDGET_STEER = (
 def turn_think_budget_check(turn_think_tokens: int, budget: int, half_fired: bool,
                             exhausted: bool):
     """Threshold latch for the cumulative per-turn reasoning budget: 'half' fires ONCE as
-    a soft steer at budget/2; 'exhausted' fires ONCE as the transition into a PERSISTENT
-    no-think state the caller holds for the rest of the turn (every subsequent step
-    decodes with thinking off — not one-shot, unlike 086's capped-stall escalation, which
-    restores thinking after a single forced action). Once exhausted, always returns
-    (None, half_fired, True) — nothing further to escalate. Returns
-    (decision, half_fired, exhausted). Pure/testable; the caller owns the state."""
+    a soft steer at budget/2; 'exhausted' fires ONCE as the transition into the throttled
+    state (see turn_think_throttle — the TB2.1 v1.0.0 run showed a blanket rest-of-turn
+    no-think mute degrades Ornith's tool-call syntax and capability over long tails,
+    plan 107). Once exhausted, always returns (None, half_fired, True) — nothing further
+    to escalate. Returns (decision, half_fired, exhausted). Pure/testable; the caller
+    owns the state."""
     if exhausted:
         return None, half_fired, True
     if turn_think_tokens >= budget:
@@ -1152,6 +1213,24 @@ def turn_think_budget_check(turn_think_tokens: int, budget: int, half_fired: boo
     if not half_fired and turn_think_tokens >= budget / 2:
         return "half", True, False
     return None, half_fired, False
+
+
+def turn_think_throttle(turn_think_tokens: int, budget: int, nothink_paid: int,
+                        rearm: int = TURN_THINK_REARM_TOK) -> bool:
+    """Should THIS step render with thinking off? A duty-cycle throttle for the
+    post-exhaustion state: crossing the budget owes one forced no-think action step,
+    and every further `rearm` think tokens spent owes one more. The caller counts the
+    no-think steps it has already paid (`nothink_paid`). Self-correcting by design —
+    a model that keeps burning reasoning is throttled toward always-off (the old
+    persistent-mute behavior), while one that stops over-thinking gets its thinking
+    back once the owed steps are paid. The v1.0.0 full run's evidence for restoring
+    rather than muting: break-filter-js spent 26 straight no-think steps after
+    exhaustion and regressed a run1 pass with garbled landing tool calls (plan 107 F1).
+    Pure/testable; never touches an in-flight generation (086 contract)."""
+    if turn_think_tokens < budget:
+        return False
+    owed = 1 + (turn_think_tokens - budget) // max(1, rearm)
+    return nothink_paid < owed
 
 
 # Injected as the review turn's task preamble. A fresh Agent on a

--- a/src/chad/levers.py
+++ b/src/chad/levers.py
@@ -256,12 +256,14 @@ LEVERS: dict[str, Lever] = {
     #     off entirely in interactive/unmetered runs, like wrapup_window. -------------
     "turn_think_budget": Lever(
         "A cumulative per-turn reasoning-token budget (wall- and decode-speed-aware, "
-        "clamped 8k-24k): a one-shot soft steer at half spent, then a PERSISTENT "
-        "no-think for the rest of the turn once spent (every later step decodes with "
-        "<think> off — not one-shot, unlike no_think_escalation above). Acts only at "
-        "step boundaries on fresh generations, never an in-flight one (086's lesson). "
-        "Off in plan mode and for read-only-intent turns. Only active with a wall "
-        "budget configured.",
+        "clamped 8k-24k): a one-shot soft steer at half spent, then a no-think "
+        "THROTTLE once spent — one forced no-think action step per 3k further think "
+        "tokens (guardrails.turn_think_throttle), so thinking restores when the model "
+        "stops over-spending; a blanket rest-of-turn mute regressed run1 passes with "
+        "garbled no-think tails (plan 107). Acts only at step boundaries on fresh "
+        "generations, never an in-flight one (086's lesson). Off in plan mode, for "
+        "read-only-intent turns, and below a 300s wall budget (short relaunch tails "
+        "belong to hard_wrapup). Only active with a wall budget configured.",
         "iter11"),
 
     # --- (103 hard wrap-up): the 085 wrapup_window nudge only lands at a step

--- a/src/chad/prompt.py
+++ b/src/chad/prompt.py
@@ -92,6 +92,16 @@ _ACTION_WORDS = (
     "handle", "patch", "correct", "write", "test", "build", "wire", "convert",
     "generate", "rewrite", "extend", "append", "document", "save",
 )
+# Run-task verbs: the ask is to put the SYSTEM in a state (start a service, boot an
+# image, install a package), not to land a file edit — completable with zero edits, so
+# these must NOT feed the `action` class (whose no-empty-diff done gate demands a landed
+# edit; arming it here would hard-block every legitimate zero-edit completion). They get
+# their own `run` class, which arms only the anti-bail nudges (TB2.1 qemu-startup,
+# plan 107 follow-up: classified neither action nor read-only, so a prose give-up with
+# 733s left sailed through the weakest path).
+_RUN_WORDS_RE = re.compile(
+    r"\b(start|launch|boot|run|serve|deploy|install|configure|mount|restart|enable"
+    r"|spin up|bring up|set up)\b")
 # Explanatory openers: an ask that legitimately ends in prose. Deliberately NARROW —
 # a bare trailing "?" doesn't count (too ambiguous), and "can/could/should you…" are
 # excluded because they're usually polite ACTION requests ("can you fix this?").
@@ -161,7 +171,11 @@ def classify_intent(user_text: str) -> dict:
                  or any(p in ut for p in _READ_ONLY_GLOBAL)
                  or any(_global_negation(p) for p in _READ_ONLY_NEGATIONS if p in ut))
     action = any(w in ut for w in _ACTION_WORDS)
-    return {"action": action, "read_only": read_only}
+    # `run`: a system-state imperative (start/boot/serve/…). Kept SEPARATE from
+    # `action` — run tasks are completable with zero file edits, so they arm the
+    # anti-bail nudges but never the edit-demanding no-empty-diff gates.
+    run = bool(_RUN_WORDS_RE.search(ut)) and not explanatory
+    return {"action": action, "read_only": read_only, "run": run}
 
 
 # Short base prompt for a spawned sub-agent. It runs in a fresh, isolated

--- a/src/chad/syntaxgate.py
+++ b/src/chad/syntaxgate.py
@@ -104,6 +104,27 @@ def _ts_error_loc(text: str, line: int) -> str:
 # error delta, not on every still-broken landing, so a streak there is unobservable.
 _BROKEN_STREAK: dict[str, int] = {}
 
+# Prose/data formats whose tree-sitter grammars exist but whose "syntax errors" are
+# noise for this gate: the language pack maps `.txt` to VIMDOC, so plain-text
+# deliverable writes (answer.txt, secret.txt, requirements.txt — the TB2.1 run1 README
+# finding, plan 107 follow-up) got grammar-checked and warned on exactly the
+# deliverable-landing write. A missing entry here costs a spurious warning, never a
+# missed real one — code languages are not listed.
+_NON_CODE_LANGS = frozenset({
+    "vimdoc", "markdown", "markdown_inline", "csv", "tsv", "psv", "text", "rst",
+    "org", "diff", "gitcommit", "git_rebase", "gitattributes", "gitignore",
+    "properties", "requirements",
+})
+
+
+def _code_lang(path: str) -> str | None:
+    """`lang_for`, filtered to languages this gate should police: None for both
+    unknown extensions and the prose/data formats above — every gate in this module
+    (warn, edit-revert, write-reject, severed-span) must skip those uniformly, or a
+    plain-text deliverable write gets warned on (or worse, REVERTED)."""
+    detected = repomap.service().lang_for(path)
+    return None if detected in _NON_CODE_LANGS else detected
+
 
 def check_syntax(path: str, before: str | None) -> str | None:
     """A warning string when the current on-disk content of `path` has a *newly
@@ -125,7 +146,7 @@ def check_syntax(path: str, before: str | None) -> str | None:
     if after == before:      # the tool didn't actually change the file — nothing to flag
         return None
 
-    lang = repomap.service().lang_for(path)
+    lang = _code_lang(path)
 
     if lang == "python":
         ap = os.path.abspath(path)
@@ -251,7 +272,7 @@ def edit_reject(path: str, before: str, after: str,
         return None
     if len(after) > _MAX_BYTES:
         return None
-    lang = repomap.service().lang_for(path)
+    lang = _code_lang(path)
     if not lang:
         return None
     if lang != "python":
@@ -359,7 +380,7 @@ def write_reject(path: str, before: str | None, content: str) -> str | None:
         return None
     if len(content) > _MAX_BYTES or (before is not None and len(before) > _MAX_BYTES):
         return None
-    lang = repomap.service().lang_for(path)
+    lang = _code_lang(path)
     if not lang:
         return None
     bash_hint = ("If this file is SUPPOSED to contain invalid syntax (a test fixture), "
@@ -568,7 +589,7 @@ def drift_warn(path: str, before: str | None, after: str) -> str | None:
         return None
     if before is None or len(before) > _MAX_BYTES or len(after) > _MAX_BYTES:
         return None
-    lang = repomap.service().lang_for(path)
+    lang = _code_lang(path)
     if not lang:
         return None
     dropped: list[str] = []

--- a/tests/test_agent_e2e.py
+++ b/tests/test_agent_e2e.py
@@ -758,34 +758,66 @@ class _BigThinkEngine(ScriptedEngine):
         return text, stats
 
 
-def _run_turn_think_budget(monkeypatch, *, ablated: bool):
+def _run_turn_think_budget(monkeypatch, *, ablated: bool, script=None,
+                           turn_budget_s=1e9):
     if ablated:
         monkeypatch.setenv("CHAD_DISABLE", "turn_think_budget")
     else:
         monkeypatch.delenv("CHAD_DISABLE", raising=False)
     stall = "<think>" + "reasoning " * 50 + "</think>"
-    eng = _BigThinkEngine([stall] * 6)
+    eng = _BigThinkEngine(script if script is not None else [stall] * 6)
     tok = _ThinkFlagTok()
     eng.tok = tok
     # A configured wall budget is required to arm the mechanism at all (like
     # wrapup_window); huge so the UNRELATED governor/wrapup checks never fire and
     # muddy the transcript this test inspects.
     agent = Agent(eng, mode="auto", thinking=True, max_gen_tokens=20000,
-                  turn_budget_s=1e9)
+                  turn_budget_s=turn_budget_s)
     agent.run_turn("change the config value")   # an action task, not read-only
     return tok.flags
 
 
-def test_turn_think_budget_forces_persistent_no_think_once_exhausted(monkeypatch):
+def test_turn_think_budget_throttles_no_think_while_overspending(monkeypatch):
     flags = _run_turn_think_budget(monkeypatch, ablated=False)
     # Each stall's ~14.7k-token think delta clears HALF (12k) on step 0 and EXHAUSTS
     # (24k) by step 1 — so step 0/1 still render thinking (the mechanism only acts on
-    # steps AFTER the threshold is crossed), then every later step is forced no-think.
+    # steps AFTER the threshold is crossed). The scripted engine keeps burning ~14.7k
+    # think tokens on EVERY later step too, so the throttle's debt (one no-think step
+    # per 3k further think tokens) grows faster than it is paid — every remaining step
+    # renders no-think, converging on the old persistent behavior for a model that
+    # never stops over-spending.
     assert flags[:2] == [True, True], flags
     assert flags[2:] and all(f is False for f in flags[2:]), flags
-    # Persistent, unlike no_think_escalation's one-shot: once it flips, it never
-    # flips back for the rest of the turn.
-    assert True not in flags[2:], flags
+
+
+def test_turn_think_budget_restores_thinking_once_debt_paid(monkeypatch):
+    # Two big-think stalls exhaust the budget (~29.4k vs 24k -> debt = 1 + 5.4k//3k
+    # = 2 no-think steps owed); the model then STOPS thinking (plain tool-call turns
+    # accrue zero think delta), so after the two owed steps are paid, thinking must
+    # RESTORE — the plan-107 fix over the v1.0.0 persistent mute, which stayed off for
+    # the rest of the turn (break-filter-js: 26 straight no-think steps, garbled
+    # landing calls, regressed a run1 pass).
+    stall = "<think>" + "reasoning " * 50 + "</think>"
+    tc = _tool_call("bash", command="echo ok")
+    flags = _run_turn_think_budget(
+        monkeypatch, ablated=False,
+        script=[stall, stall, tc, tc, tc, "All set — the config value is updated."])
+    assert flags[:2] == [True, True], flags
+    assert flags[2:4] == [False, False], flags       # paying the two owed steps
+    assert flags[4:] and all(f is True for f in flags[4:]), flags  # restored
+
+
+def test_turn_think_budget_inert_below_min_wall(monkeypatch):
+    # A short relaunch tail (wall budget under TURN_THINK_MIN_WALL_S=300) must leave
+    # the mechanism entirely inert — on the v1.0.0 run a 200s-class relaunch clamped
+    # to the LO budget and half-fired on its FIRST step, churning against the hard
+    # wrap-up landing (regex-log). The governor/wrapup paths may also act on such a
+    # short wall, so keep the script tiny.
+    stall = "<think>" + "reasoning " * 50 + "</think>"
+    flags = _run_turn_think_budget(monkeypatch, ablated=False,
+                                   script=[stall] * 3, turn_budget_s=200)
+    assert flags, "the turn should have taken at least one step"
+    assert False not in flags, flags
 
 
 def test_turn_think_budget_is_gone_when_ablated(monkeypatch):

--- a/tests/test_agent_guards.py
+++ b/tests/test_agent_guards.py
@@ -49,11 +49,13 @@ from chad.guardrails import (
     progress_note,
     relaunch_budget,
     repeat_stop_abort,
+    replenish_continue,
     review_pass_should_fire,
     think_budget,
     turn_governor,
     turn_think_budget,
     turn_think_budget_check,
+    turn_think_throttle,
     update_thrash,
     update_work_flags,
     wrapup_landing_steer,
@@ -652,6 +654,53 @@ def test_progress_note():
               + '<tool_call>{"name": "read", "arguments": {"path": "z.py"}}</tool_call>'}]
     ln = progress_note(loopy)
     check("degenerate reasoning not carried as hypothesis", "hypothesis" not in ln.lower(), ln)
+    # Rejected-completion-claim path (plan 107 follow-up — the build-pov-ray poisoning
+    # loop: the banked note carried "the build is already complete and verified" as its
+    # leading hypothesis, and all 6 relaunches re-confirmed it and re-done'd).
+    poisoned = [
+        {"role": "user", "content": "build povray"},
+        {"role": "assistant",
+         "content": ("The build is already complete and verified. Let me confirm.\n"
+                     '<tool_call>{"name": "bash", "arguments": {"command": "ls build"}}'
+                     "</tool_call>")},
+        {"role": "tool", "name": "bash", "content": "povray"},
+    ]
+    rejected = progress_note(poisoned, rejected_claim="POV-Ray 2.2 is already built")
+    check("rejected claim -> warning present", "REJECTED" in rejected, rejected)
+    check("rejected claim text is quoted (clipped)",
+          "already built" in rejected, rejected)
+    check("completion-claim hypothesis is dropped",
+          "already complete and verified" not in rejected, rejected)
+    # A genuine (non-completion) diagnosis survives even on the rejected path.
+    diagnosed = list(poisoned)
+    diagnosed[1] = {"role": "assistant",
+                    "content": ("The linker fails because unix.c is missing from build/.\n"
+                                '<tool_call>{"name": "bash", "arguments": '
+                                '{"command": "ls build"}}</tool_call>')}
+    kept = progress_note(diagnosed, rejected_claim="done")
+    check("real diagnosis survives the rejected path",
+          "unix.c is missing" in kept, kept)
+    # FP class the first regex dropped (eng-review outside-voice F1): a diagnosis that
+    # merely CONTAINS a success-ish substring is not a completion claim and must survive.
+    # "rebuild is failing" once matched bare `build\s+is\s`; "successfully reproduced"
+    # once matched the standalone verified/successful branch.
+    for diag_text, needle in (
+        ("The rebuild is failing because unix.c is missing from the target list.",
+         "rebuild is failing"),
+        ("I successfully reproduced the crash: it is an off-by-one in the parse loop.",
+         "off-by-one in the parse loop"),
+        ("Verified the repro; the bug is a null deref in frame_alloc.",
+         "null deref in frame_alloc"),
+    ):
+        d = list(poisoned)
+        d[1] = {"role": "assistant",
+                "content": (diag_text + '\n<tool_call>{"name": "bash", "arguments": '
+                            '{"command": "ls build"}}</tool_call>')}
+        note = progress_note(d, rejected_claim="task is done")
+        check(f"diagnosis survives rejected path: {needle!r}", needle in note, note)
+    # Without rejected_claim the note is unchanged from the old contract: no warning.
+    check("no rejected claim -> no warning line",
+          "REJECTED" not in progress_note(poisoned), progress_note(poisoned))
 
 
 def test_bash_result_verifies_ignores_trivial_checks():
@@ -900,6 +949,41 @@ def test_turn_think_budget_check():
     # escalate, unlike no_think_escalation's one-shot which resets after one action.
     d, half, exh = turn_think_budget_check(50000, 8000, True, True)
     check("exhausted is sticky", d is None and half and exh)
+
+
+def test_turn_think_throttle():
+    # Below budget: never throttled, regardless of paid count.
+    check("below budget -> no throttle", turn_think_throttle(7999, 8000, 0) is False)
+    # Crossing the budget owes exactly ONE no-think step until paid.
+    check("at budget, unpaid -> throttle", turn_think_throttle(8000, 8000, 0) is True)
+    check("at budget, paid -> restored", turn_think_throttle(8000, 8000, 1) is False)
+    # Every further `rearm` think tokens owes one more: 8000 + 2*3000 = 3 owed total.
+    check("2 rearm chunks past budget, 2 paid -> still owes one",
+          turn_think_throttle(14000, 8000, 2) is True)
+    check("2 rearm chunks past budget, 3 paid -> restored",
+          turn_think_throttle(14000, 8000, 3) is False)
+    # A model that keeps burning reasoning is throttled toward always-off; one that
+    # stops spending accrues no new debt and keeps its thinking once paid up.
+    check("huge overshoot, few paid -> throttle",
+          turn_think_throttle(50000, 8000, 5) is True)
+    # rearm=0 must not divide by zero (guarded to 1).
+    check("zero rearm guarded", turn_think_throttle(9000, 8000, 10**6, rearm=0) is False)
+
+
+def test_replenish_continue():
+    # More than half the wall unspent and under the cap -> grant.
+    check("early giveup, wall mostly unspent -> grant",
+          replenish_continue(12000, 637, 2) is True)
+    # Past the half-wall point -> no extras (the endgame belongs to wrap-up/landing).
+    check("more than half spent -> no grant", replenish_continue(900, 500, 2) is False)
+    # Exactly at the boundary is NOT more-than -> no grant.
+    check("exact half boundary -> no grant", replenish_continue(1000, 500, 2) is False)
+    # Absolute cap: never more than AUTO_CONTINUE_TOTAL_CAP total relaunches.
+    check("at the total cap -> no grant", replenish_continue(12000, 100, 6) is False)
+    check("just under the cap -> grant", replenish_continue(12000, 100, 5) is True)
+    # No wall budget (interactive) -> never; the explicit base allowance governs.
+    check("no wall budget -> never", replenish_continue(None, 0, 0) is False)
+    check("zero wall budget -> never", replenish_continue(0, 0, 0) is False)
 
 
 def test_review_pass_should_fire():

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -102,6 +102,32 @@ def test_intent():
           not arms_nudge("explain the slugify function"))
 
 
+def test_run_intent():
+    # Run-task class (plan 107 follow-up): system-state imperatives — completable with
+    # zero file edits — must classify `run` so the anti-bail nudges arm, WITHOUT
+    # feeding `action` (whose no-empty-diff done gate demands a landed edit).
+    qemu = ("Start the /app/alpine.iso image in qemu in such a way that I can connect "
+            "to it via `telnet 127.0.0.1 6665`. Start the image in the background and "
+            "leave it running. Block until it's ready.")
+    got = classify_intent(qemu)
+    check("qemu-startup is a run task", got["run"], got)
+    check("qemu-startup is NOT an action task (no edit demanded)",
+          not got["action"], got)
+    check("qemu-startup is not read-only", not got["read_only"], got)
+    check("service imperative is a run task",
+          classify_intent("install nginx and serve /var/www on port 80")["run"])
+    # Word boundary: 'restarting'/'rerun' style inflections must not leak via substring.
+    check("'brunch' does not classify as run",
+          not classify_intent("describe the brunch menu parser")["run"])
+    # Explanatory asks never classify run — 'explain how to start the server' ends in prose.
+    check("explain-how-to-start is not a run task",
+          not classify_intent("explain how to start the server")["run"])
+    # An edit ask that also says 'run the tests' keeps action AND gains run — harmless,
+    # the merged nudge predicate is already armed by action.
+    both = classify_intent("fix the bug in app.py and run the tests")
+    check("edit+run ask keeps action", both["action"] and both["run"], both)
+
+
 def test_open_tool_call():
     # truncated mid-call -> True (drives the "write it in parts" nudge)
     check("open <tool_call> detected",
@@ -266,6 +292,7 @@ def test_step_tool_cap():
 
 if __name__ == "__main__":
     test_intent()
+    test_run_intent()
     test_open_tool_call()
     test_mentions()
     test_detect_test_command()

--- a/tests/test_syntaxgate.py
+++ b/tests/test_syntaxgate.py
@@ -156,8 +156,33 @@ def test_indent_reject_names_enclosing_symbol():
     check("module-level: no enclosing symbol steer", "You're editing inside" not in msg2, msg2)
 
 
+def test_plain_text_never_policed():
+    # The language pack maps .txt to VIMDOC, so plain-text deliverable writes
+    # (answer.txt / secret.txt / requirements.txt — the TB2.1 run1 README finding,
+    # plan 107 follow-up) were grammar-checked and warned on exactly the
+    # deliverable-landing write. Prose/data formats are now excluded from every gate.
+    for name, content in (
+        ("answer.txt", "The flag is: ABC-123\nsecond line < > { weird ] chars\n"),
+        ("requirements.txt", "numpy>=1.24\nscipy==1.11.*\n"),
+        ("notes.md", "# heading\n<unclosed <tag [bracket\n"),
+        ("data.csv", 'a,b\n1,"unclosed quote\n'),
+    ):
+        p = _tmp(name, "")
+        res = tool_write(p, content)
+        check(f"{name} write lands", res.startswith("[wrote"), res)
+        check(f"{name} write has no syntax warning",
+              "warning" not in res and "rejected" not in res, res)
+        res = tool_edit(p, content.splitlines()[0], "replaced first line")
+        check(f"{name} edit lands without warning",
+              "warning" not in res and "rejected" not in res, res)
+    # Sanity: real code languages are still policed (guard against an over-broad list).
+    check("python still policed",
+          syntaxgate.write_reject("x.py", "", "def f(:\n") is not None)
+
+
 if __name__ == "__main__":
     test_python()
+    test_plain_text_never_policed()
     test_tree_sitter_delta()
     test_opt_out()
     test_symbol_edit()

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "chad-code"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },


### PR DESCRIPTION
# think-budget throttle, smarter relaunches, note & gate hygiene

## regression fixes

- **Think-budget exhaustion now throttles instead of muting.** The turn-level
  reasoning budget used to disable `<think>` for the *rest of the turn* once
  spent; traces showed 26 consecutive no-think steps degrading both capability
  and tool-call syntax (garbled calls in the landing). Exhaustion now costs one
  forced no-think action step per 3k further think tokens
  (`guardrails.turn_think_throttle`) — a model that keeps over-spending converges
  to the old behavior, one that stops gets its thinking back. The hard-wrap-up
  landing keeps its own unconditional no-think latch.
- **Think budget is inert below a 300s wall.** Short auto-continue tails clamped
  the budget to its floor and half-fired on their first step, churning against
  the wrap-up landing.
- **Auto-continues are wall-aware.** The fixed allowance of 2 relaunches let a
  task give up with 94.7% of a 12,000s budget unused. While >50% of the task
  wall remains unspent, extra continues are granted up to 6 total
  (`guardrails.replenish_continue`); an explicit `--auto-continue N` is honored
  as-is.

## Follow-up fixes 

- **Rejected completion claims can no longer poison progress notes.** When a
  turn ends via a done/final answer the no-empty-diff gate rejected, the banked
  note now leads with an explicit REJECTED warning and drops a working
  hypothesis that itself asserts completion. Previously a false "already built
  and verified" claim was carried into every relaunch as its leading fact, and
  each fresh attempt re-confirmed it and re-done'd (observed 6 times in a row).
- **New `run` intent class.** System-state imperatives (start/boot/serve/
  install/…) are completable with zero file edits, so they classified as neither
  action nor read-only and prose give-ups took the weakest accept path. They now
  arm the anti-bail nudges — deliberately *without* feeding the edit-demanding
  no-empty-diff gate, which would hard-block legitimate zero-edit completions.
- **Syntaxgate no longer polices prose/data files.** The tree-sitter language
  pack maps `.txt` to *vimdoc*, so plain-text deliverable writes (`answer.txt`,
  `requirements.txt`) were grammar-checked and warned — on exactly the
  deliverable-landing write. All four gates now skip non-code formats via a
  shared `_code_lang` helper.

## Validation

- `uv run pytest -q` 585 passed, ruff + mypy clean. New tests: throttle math and
  restore-after-debt e2e, replenish bounds, short-wall inertness, the run-intent
  class (real task text), rejected-claim note behavior, and four prose formats
  through write/edit unwarned.


🤖 Generated with [Claude Code](https://claude.com/claude-code)