### PR TITLE
release: 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ Tool-result economics: three additions, each individually reversible via `CHAD_D
   a re-spawn doubles the local GPU cost, and a wrongly-rejected report breaks the
   turn while a wrongly-accepted one merely restores the old behavior.
 
+Plus a privacy default flip:
+
+- **Local diagnostic traces are now opt-in (privacy-first default: off).** The
+  readable `~/.chad/session.log` trace — user query, tool-call args (bash commands,
+  write/edit content), and result previews — and the persistent input history at
+  `~/.chad/history` are no longer written by default. chad is a local, single-user
+  agent so nothing ever left the machine, but the log still landed plaintext previews
+  under `~/.chad`, so it's now enabled only when you opt in with **`CHAD_SESSION_LOG=1`**.
+  `CHAD_NO_SESSION_LOG=1` still works as a hard kill switch and wins over the opt-in.
+
 ## [1.0.3] — 2026-07-21
 
 Guardrail-interaction fixes: three cases where the model was doing fine but

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 Notable, user-visible changes.
 
+## [1.0.4] — 2026-07-22
+
+Tool-result economics: three additions, each individually reversible via `CHAD_DISABLE`.
+
+- **Edits survive typographic-punctuation drift.** A fourth edit-match rung: when
+  exact, escape-normalized, and whitespace-flexible matching all miss, the edit
+  retries with curly quotes, en/em dashes, ellipsis, and non-breaking spaces folded
+  to ASCII on both sides — the drift when the model re-types prose or docstrings it
+  saw rendered (in either direction). A unique match is still required, and the
+  result discloses the recovery.
+- **Duplicate read-only output is elided.** When a `read`/`grep`/`glob`/symbol-tool
+  result comes back byte-identical to a result still in the transcript, chad appends
+  a short pointer to the earlier copy instead of re-sending the full body — on a
+  non-trimmable prefix cache every duplicate body is prefill paid again on every
+  later step. Byte-equality against the live transcript is the safety proof: a
+  changed file, different arguments, or a compaction rewrite all break equality, so
+  content is only elided while a verbatim copy is provably still in context.
+- **Sub-agent reports with no evidence are flagged.** A `task` sub-agent that
+  returns a confident, non-empty report having dispatched zero tools answered from
+  model memory, not this repository; its folded result now carries an explicit
+  "verify with grep/read before relying on it" warning. Warn-not-reject on purpose:
+  a re-spawn doubles the local GPU cost, and a wrongly-rejected report breaks the
+  turn while a wrongly-accepted one merely restores the old behavior.
+
 ## [1.0.3] — 2026-07-21
 
 Guardrail-interaction fixes: three cases where the model was doing fine but

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -430,12 +430,21 @@ CHAD_LSP_MAX_RSS_MB=2048 uv run chad  # recycle a language server past this proc
 
 ### Session log & privacy
 
-Diagnostics log: each session appends throughput numbers and a readable trace —
-the user query, tool-call args (including bash commands and write/edit content),
-and result previews — to `~/.chad/session.log`. It's now size-bounded (rotated,
-5 MB × 3) and passes previews through a best-effort secret redactor, but it still
-records command/file previews in plaintext outside the repo, so treat it as
-sensitive. Set **`CHAD_NO_SESSION_LOG=1`** (any truthy value) to disable the session
-log entirely — chad installs a null handler and won't create `~/.chad` for the log's
-sake. (For the same privacy reason, the resumable conversation store under
-`~/.chad/sessions/` — which holds full tool args and results — is created mode `0600`.)
+Diagnostics log: when enabled, each session appends throughput numbers and a readable
+trace — the user query, tool-call args (including bash commands and write/edit content),
+and result previews — to `~/.chad/session.log`. It's size-bounded (rotated, 5 MB × 3)
+and passes previews through a best-effort secret redactor, but it still records
+command/file previews in plaintext outside the repo, so treat it as sensitive.
+
+**Privacy-first default: the trace is OFF.** chad is a local, single-user agent, so
+nothing leaves your machine — but because the log lands plaintext previews under
+`~/.chad`, it is opt-in. Set **`CHAD_SESSION_LOG=1`** (any truthy value) to turn it on;
+the same flag also enables the persistent input history at `~/.chad/history` (mode
+`0600`). When it's off, chad installs a null handler and won't create `~/.chad` for the
+log's or history's sake.
+
+**`CHAD_NO_SESSION_LOG=1`** remains a hard kill switch: if set it forces both the log
+and the history off, and wins even when `CHAD_SESSION_LOG` is also set. (For the same
+privacy reason, the resumable conversation store under `~/.chad/sessions/` — which holds
+full tool args and results, and is written only when you use `-c`/`--resume` — is created
+mode `0600`.)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,7 +14,7 @@ what you *see* to the one to reach for. The knobs themselves are documented in t
 | Mac swap-storming with other apps open | the 35B (~14 GB peak) plus your apps exceed free RAM | close apps, or force the 9B: `CHAD_MODEL=nathansutton/Ornith-1.0-9B-UD-Q4_K_XL-MLX` (see [Forcing the small model](configuration.md)) |
 | chad vanishes mid-turn — no error, **no traceback at all** | an MLX Metal abort under memory pressure; the crash happens below Python, so nothing can print | close memory-heavy apps and re-run; on a borderline box force the 9B: `CHAD_MODEL=nathansutton/Ornith-1.0-9B-UD-Q4_K_XL-MLX`. The crash report (worth attaching to a bug) lands in `~/Library/Logs/DiagnosticReports/` |
 | Disk full of old model weights | the Hugging Face cache keeps every revision | `hf cache ls` / `hf cache rm` (older CLIs: `huggingface-cli scan-cache` / `delete-cache`) |
-| Wondering what it actually did | the full, redacted trace | `~/.chad/session.log` (rotated; disable with `CHAD_NO_SESSION_LOG=1`) |
+| Wondering what it actually did | the full, redacted trace — **off by default** (privacy-first) | enable with `CHAD_SESSION_LOG=1`, then read `~/.chad/session.log` (rotated) |
 
 The through-line: a small local model rewards a **scoped** ask. "Fix the failing test in
 `tests/test_x.py`" lands; "improve my codebase" flails. When in doubt, shrink the task and

--- a/src/chad/agent.py
+++ b/src/chad/agent.py
@@ -435,6 +435,11 @@ class Agent:
         self.draft_accepted = 0
         self.think_tokens = 0   # tokens spent inside <think> blocks (reasoning overhead)
         self.think_capped = 0   # times the soft think-cap force-closed a step
+        # Real tool dispatches this agent has executed (fn actually ran — excludes
+        # terminal `done`, validation rejects, and harness-injected nudge messages,
+        # which reuse real tool names in the transcript). The evidence signal behind
+        # the sub-agent zero-evidence warning in _run_subagent.
+        self.tool_dispatches = 0
         # prefill accounting: the master cost for a local model is how many *new*
         # tokens it has to prefill across a turn (context bloat -> big prefills).
         # This is the metric symbolic/repo-map retrieval is meant to shrink.
@@ -689,12 +694,22 @@ class Agent:
             elif (not result or result.startswith("[stopped:")
                     or result.startswith("[task failed:")):
                 result = _salvage(result or "[task returned nothing]")
-        # tool_calls (not `forwards`, a speculative-decoding counter that is 0 on the
-        # normal path) is the number that diagnoses a sub-agent returning nothing: it
-        # separates "never got to search" from "searched and lost its findings".
-        log.info("TASK end | desc=%r | %.1fs | tool_calls=%d gen=%d prefill=%d | -> %s",
+            else:
+                # A confident, non-empty report produced with ZERO tool dispatches came
+                # from model memory, not this repo — the one sub-agent failure the empty/
+                # crashed salvage above cannot see, and the most dangerous fold-back: it
+                # reads as evidence (guardrails.subagent_evidence_warning).
+                warned = guardrails.subagent_evidence_warning(result, sub.tool_dispatches)
+                if warned is not None:
+                    log.info("TASK zero-evidence warning appended | desc=%r", description)
+                    result = warned
+        # tool_dispatches (not a transcript count — harness nudges reuse real tool names
+        # in tool-role messages) is the number that diagnoses a sub-agent returning
+        # nothing: it separates "never got to search" from "searched and lost its
+        # findings", and 0 with a confident report is the answered-from-memory tell.
+        log.info("TASK end | desc=%r | %.1fs | tool_dispatches=%d gen=%d prefill=%d | -> %s",
                  description, time.perf_counter() - _t0,
-                 sum(1 for m in sub.messages if m.get("role") == "tool") if sub else 0,
+                 sub.tool_dispatches if sub else 0,
                  sub.gen_tokens if sub else 0,
                  sub.prefill_tokens if sub else 0, result_preview(result or ""))
         return result or "[task returned nothing]"
@@ -1810,6 +1825,7 @@ class Agent:
                     result = "[denied by user]"
                 else:
                     _t0 = time.perf_counter()
+                    self.tool_dispatches += 1
                     try:
                         result = fn(args, self._should_stop)
                         if plan_write and result.startswith("[wrote"):
@@ -1821,6 +1837,15 @@ class Agent:
                     # whole — several calls in one step stack into one prefill, so later
                     # results only get what's left of the step budget (floor-protected).
                     result = _clip_tool_result(result, cap=_step_tool_cap(step_tool_chars))
+                    # Duplicate read-only output: if this (clipped) result is
+                    # byte-identical to a tool message still in the transcript, append a
+                    # short pointer instead of paying the body's prefill again — see
+                    # guardrails.elide_duplicate_result for the safety argument.
+                    _elided = guardrails.elide_duplicate_result(name, result, self.messages)
+                    if _elided is not None:
+                        log.info("TOOL %s duplicate result elided (%d chars)",
+                                 name, len(result))
+                        result = _elided
                     step_tool_chars += len(result)
                     if _PREFILL_TRACE:
                         self._trace_tools_pending.append([name, round(_tool_s, 4)])

--- a/src/chad/config.py
+++ b/src/chad/config.py
@@ -31,6 +31,21 @@ def eq(name: str, expected: str) -> bool:
     return os.environ.get(name) == expected
 
 
+def traces_enabled() -> bool:
+    """Whether chad may write local diagnostic traces under ~/.chad — the readable
+    `session.log` (user query, tool-call args, bash/write/edit previews, result previews)
+    and the persistent input history at ~/.chad/history.
+
+    Privacy-first default: **OFF**. chad is a local, single-user agent, so these traces
+    never leave the machine, but they still record command/file previews in plaintext
+    outside the repo — so they are opt-in. Set **`CHAD_SESSION_LOG`** (any truthy value)
+    to turn them on. `CHAD_NO_SESSION_LOG`, if set, forces them OFF and wins over the
+    opt-in (a hard kill switch, kept for compatibility with the pre-opt-in default)."""
+    if flag("CHAD_NO_SESSION_LOG"):
+        return False
+    return flag("CHAD_SESSION_LOG")
+
+
 def env_str(name, default=None):
     """The env value if set to a non-empty string, else `default`. Mirrors the common
     `os.environ.get(name) or <fallback>` idiom (empty string collapses to the default)."""

--- a/src/chad/diag.py
+++ b/src/chad/diag.py
@@ -9,8 +9,10 @@ declare done, which cache served the turn. This module is that trace.
 
 The log is bounded (5 MB x3 rotation) and previews pass through a best-effort secret
 redactor, but it still records command/file previews in plaintext outside the repo, so
-treat it as sensitive. None of this touches the model-facing transcript or the tool
-results the model sees — it is the diagnostic trace only.
+treat it as sensitive. For that reason it is **opt-in**: privacy-first, chad writes no
+trace under ~/.chad unless CHAD_SESSION_LOG is set (see config.traces_enabled). None of
+this touches the model-facing transcript or the tool results the model sees — it is the
+diagnostic trace only.
 """
 import json
 import logging
@@ -22,11 +24,12 @@ from . import config
 
 _LOG_DIR = os.path.expanduser("~/.chad")
 log = logging.getLogger("chad")
-# Local privacy opt-out: set CHAD_NO_SESSION_LOG (any truthy value) to disable the
-# diagnostic session log entirely, matching the CHAD_NO_VALIDATE convention. When opted
-# out we install a NullHandler (so the many log.info calls stay cheap no-ops and Python
-# never warns about missing handlers) and never create ~/.chad for the log's sake.
-_DISABLED = config.flag("CHAD_NO_SESSION_LOG")
+# Privacy-first default: the diagnostic session log is OFF unless opted in. Set
+# CHAD_SESSION_LOG (any truthy value) to enable it; CHAD_NO_SESSION_LOG still forces it
+# off (see config.traces_enabled). When disabled we install a NullHandler (so the many
+# log.info calls stay cheap no-ops and Python never warns about missing handlers) and
+# never create ~/.chad for the log's sake.
+_DISABLED = not config.traces_enabled()
 if _DISABLED:
     log.addHandler(logging.NullHandler())
     log.propagate = False

--- a/src/chad/guardrails.py
+++ b/src/chad/guardrails.py
@@ -1412,3 +1412,64 @@ def is_repeat_loop(seen_before: int) -> bool:
 def loop_should_abort(loop_nudges: int) -> bool:
     """After incrementing the loop-nudge counter, more than 2 nudges -> abort."""
     return loop_nudges > 2
+
+
+# --- iter-14: duplicate read-only result elision. Small models re-read files and
+# re-run searches they have already loaded; on a non-trimmable prefix cache every
+# duplicate body is appended prefill paid on every later step. Hosted harnesses solve
+# this with an opt-in changed-since parameter the model must remember to pass; here
+# the harness does it automatically. Byte-equality against the
+# LIVE transcript is the whole safety argument: a changed file, different args, or a
+# compaction rewrite/drop of the earlier message all break equality, so content is only
+# elided while a verbatim copy is provably still in the model's context.
+
+DUP_ELIDE_MIN_CHARS = 400  # below this the pointer saves nothing over the body
+
+# Read-only builtins whose output is a pure function of (args, workspace state). bash is
+# excluded even when read-only (env-dependent, side-effectful); task is excluded (a
+# sub-agent run is expensive but never byte-identical in spirit — and re-spawns already
+# have their own guard); MCP tools are excluded (openWorld results may legitimately
+# repeat, e.g. polling).
+DUP_ELIDABLE = {"read", "grep", "glob", "repo_map", "overview", "view_symbol",
+                "find_symbol", "find_refs"}
+
+
+def elide_duplicate_result(name, result, messages):
+    """The short replacement result when `result` is byte-identical to an earlier tool
+    message still in the transcript, else None. Compare AFTER clipping — the transcript
+    stores clipped content, and equality must be against what the model actually has."""
+    if not levers.enabled("dup_result_elide"):
+        return None
+    if name not in DUP_ELIDABLE or len(result) < DUP_ELIDE_MIN_CHARS:
+        return None
+    if not any(m.get("role") == "tool" and m.get("name") == name
+               and m.get("content") == result for m in messages):
+        return None
+    return (f"[identical output elided: this {name} returned exactly the same result "
+            f"as your earlier {name} above — nothing has changed. That content is "
+            f"still in your context; use it from there instead of re-running the "
+            f"call.]")
+
+
+# The zero-evidence sub-agent tell (iter-14): a confident, non-empty report produced
+# with no tool dispatches came from model memory, not the repo. Warn-not-reject: a
+# local re-spawn doubles GPU cost, a false reject breaks the turn, and a false accept
+# merely restores the pre-warning status quo.
+
+SUBAGENT_EVIDENCE_WARNING = (
+    "\n[warning: the sub-agent answered WITHOUT reading any files or running any "
+    "searches — this report is from model memory, not this repository. Verify the "
+    "claims with grep/read before relying on them.]")
+
+
+def subagent_evidence_warning(result, tool_dispatches):
+    """The result with the zero-evidence warning appended, or None when no warning is
+    due (the sub-agent did real work, the result is already a failure sentinel the
+    salvage path owns, or the lever is off)."""
+    if not levers.enabled("subagent_evidence_warn"):
+        return None
+    if tool_dispatches > 0:
+        return None
+    if not result or not result.strip() or result.startswith(("[task", "[stopped:")):
+        return None
+    return result.rstrip() + SUBAGENT_EVIDENCE_WARNING

--- a/src/chad/levers.py
+++ b/src/chad/levers.py
@@ -309,6 +309,35 @@ LEVERS: dict[str, Lever] = {
         "harassing ops-heavy tasks that legitimately run many non-read commands.",
         "iter13"),
 
+    # --- iter-14: tool-result economics (2026-07). Two ideas from a teardown of a
+    #     token-optimizing agent harness: normalize typographic unicode when matching
+    #     edits, and never re-send file content the model provably already has; both
+    #     map cleanly onto a prefill-dominated local loop. ---------------------------
+    "edit_typo_match": Lever(
+        "Fourth edit-match rung: when exact / escape-normalized / whitespace-flexible "
+        "matching all miss, retry the whitespace-flexible match with typographic "
+        "punctuation folded to ASCII on BOTH sides (curly quotes, en/em dashes, "
+        "ellipsis, non-breaking space) — the drift when a model re-types prose or "
+        "docstrings it saw rendered. Still requires a unique match; never fires on "
+        "code that matched an earlier rung. OFF loses only the recovery.",
+        "iter14"),
+    "subagent_evidence_warn": Lever(
+        "A sub-agent that returns a confident, non-empty report having dispatched ZERO "
+        "tools answered from model memory, not the repo; its folded result gets an "
+        "explicit verify-before-relying warning appended. Warn-not-reject on purpose: "
+        "a local re-spawn doubles GPU cost, and a false reject breaks the turn while a "
+        "false accept merely restores the pre-warning status quo. OFF folds the "
+        "unverified report back silently.",
+        "iter14"),
+    "dup_result_elide": Lever(
+        "A read-only tool result byte-identical to a tool message still in the "
+        "transcript is replaced with a short pointer to the earlier copy instead of "
+        "re-appending the full body to the prefill. Equality against the LIVE "
+        "transcript is the safety proof: compaction rewrites or drops old messages, "
+        "which breaks equality, so content is only elided while it is genuinely "
+        "still in context. OFF re-appends duplicate output verbatim.",
+        "iter14"),
+
     # --- from the LangChain harness-tuning playbook. -------------------------------
     "compact_notice": Lever(
         "After compaction, inject an in-band message telling the model its context was "

--- a/src/chad/levers.py
+++ b/src/chad/levers.py
@@ -355,6 +355,14 @@ LEVERS: dict[str, Lever] = {
         "Append the active model profile's prompt block to the system prompt "
         "(model-specific accommodations; see profiles.py).",
         "playbook"),
+
+    # --- from the ai-codex teardown: an index the model already has beats one it must
+    #     fetch. chad had the ranked map but only as a tool; this puts a digest in-prompt.
+    "workspace_map": Lever(
+        "Inject a ranked repo_map digest into the system-prompt dynamic tail instead of "
+        "a flat file listing, so the model orients without a reflexive step-1 repo_map "
+        "call. Degrades to the flat listing when repomap is unavailable (see prompt.py).",
+        "ai-codex"),
 }
 
 

--- a/src/chad/prompt.py
+++ b/src/chad/prompt.py
@@ -209,12 +209,20 @@ def _dynamic_context() -> list:
         f"- Shell: {os.environ.get('SHELL', 'unknown')}",
         f"- Working directory: {os.getcwd()}",
     ]
-    snapshot = _workspace_snapshot()
-    if snapshot:
+    ranked = _workspace_map()
+    if ranked:
         dynamic.append(
-            "\n# Workspace files (a real project — use grep/read to inspect before answering)\n"
-            + snapshot
+            "\n# Workspace map (ranked by reference centrality; signatures only — "
+            "call repo_map for a wider/focused map, view_symbol/read for bodies)\n"
+            + ranked
         )
+    else:
+        snapshot = _workspace_snapshot()
+        if snapshot:
+            dynamic.append(
+                "\n# Workspace files (a real project — use grep/read to inspect before answering)\n"
+                + snapshot
+            )
     test_cmd = _detect_test_command()
     if test_cmd:
         dynamic.append(
@@ -332,6 +340,30 @@ def _detect_test_command() -> str:
         except OSError:
             pass
     return ""
+
+
+def _workspace_map(budget: int = 600) -> str:
+    """A small, ranked repo_map digest for the system-prompt tail, so the model orients
+    structurally at session start instead of burning a reflexive step-1 repo_map call
+    (chad already pays for the ranked index; the tool stays for a wider/focused map).
+
+    Built once per session (build_system_prompt runs once in Agent.__init__) and reuses
+    the on-disk mtime cache, so it doesn't churn the KV prefix or add per-turn cost.
+    Returns "" on any failure so _dynamic_context falls back to the flat file listing —
+    keeping behavior identical on wheel-less platforms where repomap degrades to empty."""
+    from . import levers
+    if not levers.enabled("workspace_map"):
+        return ""
+    try:
+        from . import repomap
+        digest = repomap.service().repo_map(budget_tokens=budget)
+    except Exception:  # noqa: BLE001 - orientation is best-effort; degrade to snapshot
+        return ""
+    # repo_map's non-map sentinels ("[no source files found]", "[interrupted]") and any
+    # empty/whitespace result mean "no usable map" — fall back rather than inject noise.
+    if not digest or not digest.strip() or digest.strip().startswith("["):
+        return ""
+    return digest
 
 
 def _workspace_snapshot(limit: int = 60) -> str:

--- a/src/chad/tools.py
+++ b/src/chad/tools.py
@@ -382,10 +382,30 @@ def _line_offsets(data: str):
     return offs
 
 
-def _ws_flexible_spans(data: str, old: str):
+# Typographic punctuation folded to ASCII for the last-resort edit match (iter-14).
+# Only characters a model plausibly re-types the other way when
+# quoting prose/docstrings it saw rendered: quotes, dashes, ellipsis, nbsp. Deliberately
+# NOT general unicode normalization — identifiers and string literals in code must not
+# be conflated beyond this list.
+_TYPO_MAP = str.maketrans({
+    "‘": "'", "’": "'", "‚": "'", "‛": "'",   # single quotes
+    "“": '"', "”": '"', "„": '"',                  # double quotes
+    "–": "-", "—": "-", "―": "-",                  # en/em/horizontal dash
+    " ": " ",                                                # non-breaking space
+})
+
+
+def _norm_typo(s: str) -> str:
+    return s.translate(_TYPO_MAP).replace("…", "...")
+
+
+def _ws_flexible_spans(data: str, old: str, typo: bool = False):
     """Char spans (start, end) where `old` matches a run of lines in `data` ignoring
-    each line's leading/trailing whitespace. Skips all-blank patterns (too ambiguous)."""
-    norm = [l.strip() for l in old.strip("\n").split("\n")]
+    each line's leading/trailing whitespace. Skips all-blank patterns (too ambiguous).
+    With `typo=True`, additionally folds typographic punctuation to ASCII on both
+    sides before comparing (the match is still line-exact otherwise)."""
+    fold = (lambda l: _norm_typo(l).strip()) if typo else (lambda l: l.strip())
+    norm = [fold(l) for l in old.strip("\n").split("\n")]
     if not any(norm):
         return []
     dlines = data.split("\n")
@@ -393,7 +413,7 @@ def _ws_flexible_spans(data: str, old: str):
     n = len(norm)
     spans = []
     for i in range(len(dlines) - n + 1):
-        if [dlines[i + j].strip() for j in range(n)] == norm:
+        if [fold(dlines[i + j]) for j in range(n)] == norm:
             spans.append((offs[i], offs[i + n - 1] + len(dlines[i + n - 1])))
     return spans
 
@@ -647,8 +667,16 @@ def tool_edit(path: str, old: str, new: str) -> str:
             return f"[old string appears {c} times; make it unique by including more surrounding lines]"
 
     # (3) whitespace-flexible: indentation / trailing-space drift, still requiring uniqueness.
+    # (4) typography-normalized: same match with curly quotes / en–em dashes / ellipsis /
+    #     nbsp folded to ASCII on both sides — the drift when the model re-types prose it
+    #     saw rendered (or the file uses typographic punctuation the model ASCII-fied).
+    #     Tried only when rung 3 found nothing, and still requires a unique match.
     probe = uold if uold != old else old
     spans = _ws_flexible_spans(data, probe)
+    how = "indentation/whitespace"
+    if not spans and levers.enabled("edit_typo_match"):
+        spans = _ws_flexible_spans(data, probe, typo=True)
+        how = "typographic quotes/dashes and whitespace"
     if len(spans) == 1:
         s, e = spans[0]
         head = data[s:e].split("\n")[0]
@@ -669,7 +697,7 @@ def tool_edit(path: str, old: str, new: str) -> str:
             landed = raw
         else:
             res = _apply_edit(path, data, data[:s] + repl + data[e:],
-                              " (recovered: matched ignoring indentation/whitespace)"
+                              f" (recovered: matched ignoring {how})"
                               + (note_new if used_unew else ""))
             landed = repl
         # Echo the landed region with visible whitespace (ky-timeoutMessage, session
@@ -678,7 +706,7 @@ def tool_edit(path: str, old: str, new: str) -> str:
         # `_apply_edit` can return a syntaxgate rejection or drift warning instead.
         return res + _landed_hint(landed) if res.startswith("[edited") else res
     if len(spans) > 1:
-        return (f"[old string matches {len(spans)} places ignoring whitespace; include "
+        return (f"[old string matches {len(spans)} places ignoring {how}; include "
                 f"more surrounding lines to make it unique]")
 
     return (f"[old string not found; no change made.{_closest_hint(data, old)}]"

--- a/src/chad/tui.py
+++ b/src/chad/tui.py
@@ -239,9 +239,10 @@ class _ChadCompleter(Completer):
 
 def _make_history():
     """Persistent input history: `FileHistory` at ~/.chad/history (mode 0600 — it can
-    hold typed paths/snippets, like the session store), or `InMemoryHistory` when
-    CHAD_NO_SESSION_LOG is set. Falls back to in-memory on any filesystem error."""
-    if config.flag("CHAD_NO_SESSION_LOG"):
+    hold typed paths/snippets, like the session store), or `InMemoryHistory` when local
+    traces are not opted in (see config.traces_enabled). Falls back to in-memory on any
+    filesystem error."""
+    if not config.traces_enabled():
         return InMemoryHistory()
     path = os.path.expanduser("~/.chad/history")
     try:

--- a/tests/test_agent_guards.py
+++ b/tests/test_agent_guards.py
@@ -1163,3 +1163,66 @@ if __name__ == "__main__":
     test_classify_sync_kind()
     print(f"\n{PASS} passed, {FAIL} failed")
     raise SystemExit(1 if FAIL else 0)
+
+
+def test_dup_result_elide():
+    # iter-14: a read-only result byte-identical to a tool message
+    # still in the transcript is elided to a short pointer; anything that breaks
+    # byte-equality (changed file, different args, compaction rewrite) flows through.
+    from chad.guardrails import DUP_ELIDE_MIN_CHARS, elide_duplicate_result
+    body = "1  line\n" * 200  # comfortably over the threshold
+    check("dup: body over threshold", len(body) >= DUP_ELIDE_MIN_CHARS)
+    msgs = [{"role": "tool", "name": "read", "content": body}]
+    hit = elide_duplicate_result("read", body, msgs)
+    check("dup: identical read elided", hit is not None and "elided" in hit, hit)
+    check("dup: pointer is short", hit is not None and len(hit) < 300, hit)
+    check("dup: changed content flows through",
+          elide_duplicate_result("read", body + "x", msgs) is None)
+    check("dup: name mismatch flows through",
+          elide_duplicate_result("grep", body, msgs) is None)
+    check("dup: bash never elided",
+          elide_duplicate_result(
+              "bash", body, [{"role": "tool", "name": "bash", "content": body}]) is None)
+    check("dup: short result flows through",
+          elide_duplicate_result(
+              "read", "[empty]", [{"role": "tool", "name": "read", "content": "[empty]"}]) is None)
+    # a compaction rewrite (head/tail collapse) breaks equality -> full result again
+    collapsed = body[:100] + "\n[...collapsed...]\n" + body[-50:]
+    check("dup: collapsed prior flows through",
+          elide_duplicate_result(
+              "read", body, [{"role": "tool", "name": "read", "content": collapsed}]) is None)
+
+
+def test_dup_result_elide_lever_off(monkeypatch):
+    from chad.guardrails import elide_duplicate_result
+    monkeypatch.setenv("CHAD_DISABLE", "dup_result_elide")
+    body = "y" * 500
+    check("dup lever off: no elision",
+          elide_duplicate_result(
+              "read", body, [{"role": "tool", "name": "read", "content": body}]) is None)
+
+
+def test_subagent_evidence_warning():
+    # iter-14: a confident report with zero tool dispatches is the answered-from-memory
+    # tell; it gets a verify warning appended. Real work, failure sentinels (the salvage
+    # path owns those), and empty results are left alone.
+    from chad.guardrails import SUBAGENT_EVIDENCE_WARNING, subagent_evidence_warning
+    report = "The bug is in utils.py line 40: off-by-one in the loop bound."
+    warned = subagent_evidence_warning(report, 0)
+    check("evidence: zero-dispatch report is warned",
+          warned == report + SUBAGENT_EVIDENCE_WARNING, warned)
+    check("evidence: real work passes clean",
+          subagent_evidence_warning(report, 3) is None)
+    check("evidence: failure sentinel untouched",
+          subagent_evidence_warning("[task returned nothing]", 0) is None)
+    check("evidence: stopped sentinel untouched",
+          subagent_evidence_warning("[stopped: loop]", 0) is None)
+    check("evidence: empty result untouched",
+          subagent_evidence_warning("   ", 0) is None)
+
+
+def test_subagent_evidence_warning_lever_off(monkeypatch):
+    from chad.guardrails import subagent_evidence_warning
+    monkeypatch.setenv("CHAD_DISABLE", "subagent_evidence_warn")
+    check("evidence lever off: no warning",
+          subagent_evidence_warning("confident memory answer", 0) is None)

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -245,3 +245,38 @@ if __name__ == "__main__":
     test_ws_only_edit_result_echoes_landed_indentation()
     print(f"\n{PASS} passed, {FAIL} failed")
     raise SystemExit(1 if FAIL else 0)
+
+
+def test_typo_recovery_file_has_unicode_model_sends_ascii():
+    # iter-14: file uses typographic punctuation, the model
+    # re-types it ASCII-fied. Rungs 1-3 miss; the typo-normalized rung must land.
+    before = 'MSG = "cache — warm start"\nprint(MSG)\n'
+    res, after = run(before, 'MSG = "cache - warm start"', 'MSG = "cache - hot start"')
+    check("typo(ascii old): edit landed", res.startswith("[edited"), res)
+    check("typo(ascii old): note names the rung", "typographic" in res, res)
+    check("typo(ascii old): new text is verbatim", 'MSG = "cache - hot start"' in after, after)
+    check("typo(ascii old): rest untouched", "print(MSG)" in after, after)
+
+
+def test_typo_recovery_model_sends_unicode_file_has_ascii():
+    # Opposite direction: the model quotes with curly punctuation, file is ASCII.
+    before = "note = 'it is fine...'\nx = 1\n"
+    res, after = run(before, "note = ‘it is fine…’", "note = 'all good...'")
+    check("typo(unicode old): edit landed", res.startswith("[edited"), res)
+    check("typo(unicode old): replacement present", "note = 'all good...'" in after, after)
+
+
+def test_typo_recovery_requires_unique_match():
+    # SAFETY: two lines that both match after folding must be rejected, file untouched.
+    before = 'a = "x — y"\nb = "x — y"\n'
+    res, after = run(before, '"x - y"', '"z"')
+    check("typo ambiguous: rejected", not res.startswith("[edited"), res)
+    check("typo ambiguous: file untouched", after == before, after)
+
+
+def test_typo_recovery_lever_off(monkeypatch):
+    monkeypatch.setenv("CHAD_DISABLE", "edit_typo_match")
+    before = 'MSG = "cache — warm start"\nprint(MSG)\n'
+    res, after = run(before, 'MSG = "cache - warm start"', 'MSG = "x"')
+    check("typo lever off: not found", "not found" in res, res)
+    check("typo lever off: file untouched", after == before, after)

--- a/tests/test_feel_pack.py
+++ b/tests/test_feel_pack.py
@@ -5,8 +5,8 @@ pin the *logic*:
 
   * item 2 — slash-command matching, `@`-token extraction, and IGNORE_DIRS-aware path
     completion (the completer itself just forwards to these);
-  * item 3 — FileHistory at ~/.chad/history is created 0600 and CHAD_NO_SESSION_LOG
-    falls back to in-memory;
+  * item 3 — FileHistory at ~/.chad/history is created 0600 only when opted in
+    (CHAD_SESSION_LOG); off by default and under CHAD_NO_SESSION_LOG it stays in-memory;
   * item 4 — pygments highlighting is byte-identical to the plain path when the import is
     unavailable (monkeypatched off) and adds color when present, with the +/- diff
     coloring left as the outer layer.
@@ -68,8 +68,11 @@ def test_path_matches_respects_ignore_dirs(tmp_path):
 
 # -- item 3: persistent history ---------------------------------------------
 
-def test_file_history_is_created_0600(tmp_path, monkeypatch):
+def test_file_history_opt_in_is_created_0600(tmp_path, monkeypatch):
+    # Persistent history is a local trace, so it follows the same opt-in gate as the
+    # session log: only written when CHAD_SESSION_LOG is set.
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CHAD_SESSION_LOG", "1")
     monkeypatch.delenv("CHAD_NO_SESSION_LOG", raising=False)
     h = _make_history()
     p = tmp_path / ".chad" / "history"
@@ -78,8 +81,21 @@ def test_file_history_is_created_0600(tmp_path, monkeypatch):
     assert stat.S_IMODE(os.stat(p).st_mode) == 0o600
 
 
-def test_history_opt_out_is_in_memory(tmp_path, monkeypatch):
+def test_history_off_by_default_is_in_memory(tmp_path, monkeypatch):
+    # Privacy-first default: with no opt-in, history stays in memory and ~/.chad/history
+    # is never written.
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CHAD_SESSION_LOG", raising=False)
+    monkeypatch.delenv("CHAD_NO_SESSION_LOG", raising=False)
+    h = _make_history()
+    assert type(h).__name__ == "InMemoryHistory"
+    assert not (tmp_path / ".chad" / "history").exists()
+
+
+def test_history_no_session_log_overrides_opt_in(tmp_path, monkeypatch):
+    # The hard kill switch wins even when the opt-in is set.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CHAD_SESSION_LOG", "1")
     monkeypatch.setenv("CHAD_NO_SESSION_LOG", "1")
     h = _make_history()
     assert type(h).__name__ == "InMemoryHistory"

--- a/tests/test_lever_bite.py
+++ b/tests/test_lever_bite.py
@@ -674,6 +674,43 @@ def test_playbook_levers_have_dedicated_suites(monkeypatch):
     assert profiles.prompt_block(None) == ""
 
 
+# === iter-14 ===============================================================
+
+def test_edit_typo_match_bite(monkeypatch, tmp_path):
+    """ASCII-fied `old` against a typographic file lands only while the rung is on."""
+    n = bite("edit_typo_match")
+    src = 'MSG = "cache — warm"\n'
+    p = tmp_path / "f.py"
+    on(monkeypatch)
+    p.write_text(src)
+    assert tools.tool_edit(
+        str(p), 'MSG = "cache - warm"', 'MSG = "cache - hot"').startswith("[edited")
+    off(monkeypatch, n)
+    p.write_text(src)
+    assert "not found" in tools.tool_edit(
+        str(p), 'MSG = "cache - warm"', 'MSG = "cache - hot"')
+
+
+def test_dup_result_elide_bite(monkeypatch):
+    """An identical read-only result is elided only while the lever is on."""
+    n = bite("dup_result_elide")
+    body = "z" * 500
+    msgs = [{"role": "tool", "name": "read", "content": body}]
+    on(monkeypatch)
+    assert guardrails.elide_duplicate_result("read", body, msgs) is not None
+    off(monkeypatch, n)
+    assert guardrails.elide_duplicate_result("read", body, msgs) is None
+
+
+def test_subagent_evidence_warn_bite(monkeypatch):
+    """A zero-dispatch confident report is warned only while the lever is on."""
+    n = bite("subagent_evidence_warn")
+    on(monkeypatch)
+    assert guardrails.subagent_evidence_warning("found it in a.py:1", 0) is not None
+    off(monkeypatch, n)
+    assert guardrails.subagent_evidence_warning("found it in a.py:1", 0) is None
+
+
 # === the coverage contract =================================================
 
 def test_every_registered_lever_has_a_bite_test():

--- a/tests/test_lever_bite.py
+++ b/tests/test_lever_bite.py
@@ -711,6 +711,18 @@ def test_subagent_evidence_warn_bite(monkeypatch):
     assert guardrails.subagent_evidence_warning("found it in a.py:1", 0) is None
 
 
+def test_workspace_map_bite(monkeypatch):
+    """The system prompt carries the ranked repo_map digest only while the lever is on;
+    off, it falls back to the flat file listing."""
+    from chad import prompt
+    n = bite("workspace_map")
+    on(monkeypatch)
+    assert "# Workspace map" in prompt.build_system_prompt("ornith")
+    off(monkeypatch, n)
+    p = prompt.build_system_prompt("ornith")
+    assert "# Workspace map" not in p and "# Workspace files" in p
+
+
 # === the coverage contract =================================================
 
 def test_every_registered_lever_has_a_bite_test():

--- a/tests/test_log_redaction.py
+++ b/tests/test_log_redaction.py
@@ -77,30 +77,55 @@ def test_leaves_normal_text_unchanged():
         check(f"unchanged: {normal!r}", _redact(normal) == normal)
 
 
-def test_session_log_opt_out():
-    # CHAD_NO_SESSION_LOG opts out of the diagnostic file log. diag installs its handler
-    # at import time, so test in a fresh subprocess (reload would leave the first import's
-    # RotatingFileHandler attached to the shared named logger). Assert only a NullHandler
-    # is attached and that redact/args_preview still work without the file handler.
+def _diag_handler_names(**env_overrides):
+    # diag installs its handler at import time, so probe in a fresh subprocess (reload
+    # would leave the first import's RotatingFileHandler attached to the shared named
+    # logger). Returns the list of handler type names on diag.log, and asserts redact/
+    # args_preview still work regardless of whether the file handler is installed.
     import os
     import subprocess
     import sys
+    import tempfile
 
     script = (
         "from chad import diag\n"
-        "import logging\n"
         "diag.log.info('x')\n"
         "names = [type(h).__name__ for h in diag.log.handlers]\n"
-        "assert names == ['NullHandler'], names\n"
         "assert diag.redact('a' * 32) == '<redacted:32>'\n"
         "assert diag.args_preview({'k': 'v'})\n"
-        "print('OK', names)\n"
+        "print('NAMES', names)\n"
     )
-    env = dict(os.environ, CHAD_NO_SESSION_LOG="1")
-    out = subprocess.run([sys.executable, "-c", script], env=env,
-                         capture_output=True, text=True)
-    check(f"opt-out subprocess OK (stderr={out.stderr})", out.returncode == 0)
-    check("only NullHandler attached", "OK ['NullHandler']" in out.stdout)
+    # Point HOME at a throwaway dir so an *enabled* run can't touch the real ~/.chad.
+    with tempfile.TemporaryDirectory() as home:
+        env = dict(os.environ, HOME=home)
+        for k in ("CHAD_SESSION_LOG", "CHAD_NO_SESSION_LOG"):
+            env.pop(k, None)
+        env.update(env_overrides)
+        out = subprocess.run([sys.executable, "-c", script], env=env,
+                             capture_output=True, text=True)
+    check(f"subprocess OK (stderr={out.stderr})", out.returncode == 0)
+    line = next(ln for ln in out.stdout.splitlines() if ln.startswith("NAMES "))
+    import ast
+    return ast.literal_eval(line[len("NAMES "):])
+
+
+def test_session_log_off_by_default():
+    # Privacy-first: with neither env var set, the diagnostic file log is OFF — only a
+    # NullHandler is attached and ~/.chad is never created for the log's sake.
+    check("default off → only NullHandler", _diag_handler_names() == ["NullHandler"])
+
+
+def test_session_log_opt_in():
+    # CHAD_SESSION_LOG opts in: the RotatingFileHandler is installed.
+    names = _diag_handler_names(CHAD_SESSION_LOG="1")
+    check(f"opt-in → RotatingFileHandler attached ({names})",
+          "RotatingFileHandler" in names)
+
+
+def test_no_session_log_overrides_opt_in():
+    # CHAD_NO_SESSION_LOG is a hard kill switch: it wins even when the opt-in is also set.
+    names = _diag_handler_names(CHAD_SESSION_LOG="1", CHAD_NO_SESSION_LOG="1")
+    check(f"force-off wins over opt-in → NullHandler ({names})", names == ["NullHandler"])
 
 
 if __name__ == "__main__":

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -345,7 +345,14 @@ def test_normal_parent_never_spawns_mutating_subagent(monkeypatch):
     default read-only request stays silent. run_turn is stubbed class-level so no model
     or real sub-agent turn is needed."""
     from chad.agent import Agent
-    monkeypatch.setattr(Agent, "run_turn", lambda self, prompt, stream=True: "ok")
+
+    def _stub_run_turn(self, prompt, stream=True):
+        # Simulate a sub-agent that did real work: without a dispatch the (on-topic
+        # elsewhere) zero-evidence warning would append to "ok" and muddy this check.
+        self.tool_dispatches += 1
+        return "ok"
+
+    monkeypatch.setattr(Agent, "run_turn", _stub_run_turn)
     agent = _mk_agent(mode="normal")
     agent.engine.push_cache = lambda: None
     agent.engine.pop_cache = lambda: None


### PR DESCRIPTION
Tool-result economics: three additions, each individually reversible via `CHAD_DISABLE`.

- **Edits survive typographic-punctuation drift.** A fourth edit-match rung: when
  exact, escape-normalized, and whitespace-flexible matching all miss, the edit
  retries with curly quotes, en/em dashes, ellipsis, and non-breaking spaces folded
  to ASCII on both sides — the drift when the model re-types prose or docstrings it
  saw rendered (in either direction). A unique match is still required, and the
  result discloses the recovery.
- **Duplicate read-only output is elided.** When a `read`/`grep`/`glob`/symbol-tool
  result comes back byte-identical to a result still in the transcript, chad appends
  a short pointer to the earlier copy instead of re-sending the full body — on a
  non-trimmable prefix cache every duplicate body is prefill paid again on every
  later step. Byte-equality against the live transcript is the safety proof: a
  changed file, different arguments, or a compaction rewrite all break equality, so
  content is only elided while a verbatim copy is provably still in context.
- **Sub-agent reports with no evidence are flagged.** A `task` sub-agent that
  returns a confident, non-empty report having dispatched zero tools answered from
  model memory, not this repository; its folded result now carries an explicit
  "verify with grep/read before relying on it" warning. Warn-not-reject on purpose:
  a re-spawn doubles the local GPU cost, and a wrongly-rejected report breaks the
  turn while a wrongly-accepted one merely restores the old behavior.

Plus a privacy default flip:

- **Local diagnostic traces are now opt-in (privacy-first default: off).** The
  readable `~/.chad/session.log` trace — user query, tool-call args (bash commands,
  write/edit content), and result previews — and the persistent input history at
  `~/.chad/history` are no longer written by default. chad is a local, single-user
  agent so nothing ever left the machine, but the log still landed plaintext previews
  under `~/.chad`, so it's now enabled only when you opt in with **`CHAD_SESSION_LOG=1`**.
  `CHAD_NO_SESSION_LOG=1` still works as a hard kill switch and wins over the opt-in.

And a session-start orientation change:

- **A lightweight workspace map replaces the flat file listing.** The system-prompt
  tail now opens with a small, ranked `repo_map` digest — signatures only, ranked by
  reference centrality — instead of a flat file listing, so the model orients
  structurally at session start rather than burning a reflexive step-1 `repo_map`
  call (the tool stays for a wider or focused map). It's built once per session from
  the on-disk mtime cache, so it doesn't churn the KV prefix or add per-turn cost, and
  degrades cleanly to the old flat listing wherever repomap is unavailable (e.g.
  wheel-less platforms). On by default; reversible via `CHAD_DISABLE`.
