### PR TITLE
feat(cli): add --model size override for the RAM-aware model pick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Notable, user-visible changes.
 
+## [Unreleased]
+
+- **`--model` size override.** chad still picks a model RAM-aware by default; the new
+  `--model` flag is the escape hatch — `--model 9b` / `--model 35b` force a size,
+  `--model auto` forces the RAM pick, and any HF repo id / local dir works too. It's the
+  CLI twin of `CHAD_MODEL` and wins over it when both are set. Forcing the 35B where RAM
+  looks too small (or is undetectable) is honored but warns first — the harness advises,
+  you decide. Not a model picker: launch-time only, nothing persisted.
+
 ## [1.0.4] — 2026-07-22
 
 Tool-result economics: three additions, each individually reversible via `CHAD_DISABLE`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -210,6 +210,7 @@ CHAD_CTX_RESERVE_GB=2.5 uv run chad      # scratch RAM held back when auto-sizin
 CHAD_CTX_SLOPE_FACTOR=1.0 uv run chad    # per-token cost multiplier for that auto-sizing (default
                                          # 1.75: measured peak grows ~1.75x the raw KV bytes/token)
 CHAD_MODEL=/path/to/mlx-model uv run chad  # power-user escape hatch: run a different MLX model
+                                         # (also: --model 9b|35b|auto|<repo> — the CLI twin, wins over this)
 CHAD_PREFILL_CHUNK=1024 uv run chad      # force a fixed prefill chunk (default: adaptive — MoE 2048
                                          # / dense 512, decaying to 256 as context+pressure grow)
 CHAD_NO_MEMORY_CLAMP=1  uv run chad      # A/B knob: skip the Metal allocator clamps installed at load
@@ -240,13 +241,24 @@ retries. `CHAD_NO_MEMORY_CLAMP=1` disables the clamps (A/B). The compaction thre
 additionally respects host-physical free memory (pressure from Docker or other apps
 that the Metal budget can't see) and is re-checked between turns.
 
-**Forcing the small model.** `CHAD_MODEL` also names another Ornith on Hugging Face, so
-it doubles as the "use the 9B" recipe. chad's default keys on *physical* RAM, so a 24 GB
-Mac with a lot already resident still gets the 35B (~14 GB peak) and can swap-thrash —
-close other apps, or pin the 9B (~5 GB) for the session:
+**Forcing a size (`--model`).** chad's default keys on *physical* RAM, so a 24 GB Mac
+with a lot already resident still gets the 35B (~14 GB peak) and can swap-thrash — close
+other apps, or force the size for the session. The `--model` flag is the ergonomic way:
 
 ```bash
-CHAD_MODEL=nathansutton/Ornith-1.0-9B-UD-Q4_K_XL-MLX uv run chad
+uv run chad --model 9b     # pin the small model (~5 GB) regardless of RAM
+uv run chad --model 35b    # force the big model; warns first if RAM looks too small
+uv run chad --model auto   # explicit RAM-aware pick (ignores CHAD_MODEL if it's set)
+```
+
+`--model` is the CLI twin of `CHAD_MODEL`: it also accepts any HF repo id / local dir,
+and it **wins over `CHAD_MODEL`** when both are set. Precedence is `--model` → `CHAD_MODEL`
+→ the RAM-aware default. Forcing `35b` under the RAM threshold is honored but prints a
+one-line OOM warning first — the harness advises, you decide. The env spelling still works
+and is handy for pinning across a whole shell session:
+
+```bash
+CHAD_MODEL=nathansutton/Ornith-1.0-9B-UD-Q4_K_XL-MLX uv run chad   # env equivalent of --model 9b
 ```
 
 ### Alternate backend (remote)

--- a/src/chad/cli.py
+++ b/src/chad/cli.py
@@ -205,29 +205,56 @@ def _detect_ram_gb():
         return None
 
 
-def _pick_model():
+def _resolve(local, repo):
+    """Prefer a locally-built models/ dir over the HF repo when it exists."""
+    return local if os.path.isdir(local) else repo
+
+
+def _pick_model(override=None):
     """Resolve the model id and a human label for *why* it was chosen.
 
-    Order: explicit CHAD_MODEL override → RAM-aware default (35B on big boxes, 9B on
-    small) → prefer a locally-built models/ dir over the HF repo when it exists.
+    Precedence: --model override (the `override` arg) → CHAD_MODEL env → RAM-aware
+    default (35B on big boxes, 9B on small). Size aliases '9b'/'35b' force that size;
+    'auto' forces the RAM pick even when CHAD_MODEL is set; anything else is a literal
+    HF repo id / local dir. For every resolved size, prefer a locally-built models/
+    dir over the HF repo.
+
+    An override that forces the 35B where RAM would not (small or undetectable RAM)
+    warns on stderr and proceeds — the harness advises, the caller decides.
     """
-    env = config.env_str("CHAD_MODEL")
-    if env:
-        return env, "CHAD_MODEL override"
+    # --model wins over CHAD_MODEL; default=None on the flag distinguishes "not passed"
+    # from an explicit "auto" (which forces the RAM pick, ignoring the env).
+    choice = override if override is not None else config.env_str("CHAD_MODEL")
+    source = "--model" if override is not None else "CHAD_MODEL"
+    if choice and choice.strip().lower() != "auto":
+        c = choice.strip().lower()
+        if c in ("9b", "35b"):
+            model_id = (_resolve(_LOCAL_9B, _HF_9B) if c == "9b"
+                        else _resolve(_LOCAL_35B, _HF_35B))
+            if c == "35b":
+                ram = _detect_ram_gb()
+                if ram is None or ram < _BIG_RAM_GB:
+                    got = "undetectable" if ram is None else f"{ram:.0f} GB"
+                    sys.stderr.write(
+                        f"chad: --model 35b forced (RAM {got} < ~{_BIG_RAM_GB:.0f} GB "
+                        f"recommended); the 35B needs ~32 GB resident and may OOM or "
+                        f"thrash. Proceeding as asked.\n")
+            return model_id, f"{c.upper()} ({source} override)"
+        return choice, f"{source} override"  # literal repo/dir — unchanged behavior
     ram = _detect_ram_gb()
     if ram is None:
         # RAM unreadable -> the safe (smaller) model: a wrong 9B costs capability, a
         # wrong 35B costs a 12 GB download and possibly an OOM'd first session.
         local, repo = _LOCAL_9B, _HF_9B
         why = "9B (RAM undetectable — choosing the safe smaller model; " \
-              "set CHAD_MODEL to override)"
+              "set CHAD_MODEL or --model to override)"
     elif ram < _BIG_RAM_GB:
         local, repo = _LOCAL_9B, _HF_9B
         why = f"9B (default; {ram:.0f} GB RAM < {_BIG_RAM_GB:.0f} GB, 35B would be tight)"
     else:
         local, repo = _LOCAL_35B, _HF_35B
         why = "35B (default)"
-    return (local if os.path.isdir(local) else repo), why
+    return _resolve(local, repo), why
 
 
 def _model_download_gb(model_id):
@@ -406,6 +433,14 @@ def main():
                          "fresh-context turn to independently verify the deliverables and fix "
                          "any mismatch. Off by default (needs --turn-budget-s to arm); also "
                          "CHAD_REVIEW_PASS=1.")
+    # Model override. chad picks a size RAM-aware by default (the harness knows best);
+    # this is the escape hatch, the CLI twin of CHAD_MODEL with friendly size aliases.
+    ap.add_argument("--model", default=None,
+                    help="override the RAM-aware model pick: 'auto' (default behavior), "
+                         "'9b', '35b', or any HF repo id / local dir. The CLI twin of "
+                         "CHAD_MODEL; --model wins if both are set, and '--model auto' "
+                         "forces the RAM pick even when CHAD_MODEL is set. The harness "
+                         "picks well by default — reach for this only to force a size.")
     # Backend selection. Default 'mlx' is the in-process engine and the whole point of
     # chad; 'llama' drives a llama.cpp server's raw /completion with token-id prompts +
     # real cache telemetry (see completion_engine.py) — the arm used when chad runs inside
@@ -469,7 +504,8 @@ def main():
         from . import prove
         sys.exit(prove.run(args))
     # Ornith; no draft, ever. RAM-aware default, local-dir-preferred, HF fallback.
-    model_id, why = _pick_model()
+    # --model (or CHAD_MODEL) overrides the RAM pick; see _pick_model.
+    model_id, why = _pick_model(args.model)
 
     # Advanced, rarely-touched knobs live in env vars to keep the CLI sane:
     #   CHAD_MAX_CONTEXT       YaRN-extend the window (e.g. 131072 for 128k)

--- a/src/chad/prove.py
+++ b/src/chad/prove.py
@@ -301,9 +301,9 @@ def run(args):
         cli._preflight("mlx")
     except SystemExit:
         return 2
-    if os.environ.get("CHAD_MODEL"):
-        sys.stderr.write("[prove pins the validated 9B — CHAD_MODEL is ignored "
-                         "for this run]\n")
+    if os.environ.get("CHAD_MODEL") or getattr(args, "model", None):
+        sys.stderr.write("[prove pins the validated 9B — CHAD_MODEL and --model are "
+                         "ignored for this run]\n")
     model_id = cli._HF_9B
     invoking_dir = os.getcwd()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -154,6 +154,103 @@ def test_pick_model_prefers_local_dir(monkeypatch):
     check("local 35B preferred over HF repo", model == cli._LOCAL_35B, model)
 
 
+def test_pick_model_flag_auto_ignores_env(monkeypatch):
+    # '--model auto' forces the RAM pick even when CHAD_MODEL is set: the env must NOT
+    # win. Big box + no local dirs -> the 35B default, not the env value.
+    monkeypatch.setenv("CHAD_MODEL", "/env/repo")
+    monkeypatch.setattr(os.path, "isdir", lambda p: False)
+    monkeypatch.setattr(cli, "_detect_ram_gb", lambda: 64.0)
+    model, why = cli._pick_model("auto")
+    check("--model auto ignores env, RAM-picks 35B", model == cli._HF_35B, model)
+    check("--model auto reason is a default", "default" in why, why)
+
+
+def test_pick_model_flag_9b_both_ram(monkeypatch, capsys):
+    # Forcing 9B yields 9B on a big box AND a small box, and NEVER warns (9B is always
+    # safe). No local dirs -> HF repo.
+    monkeypatch.delenv("CHAD_MODEL", raising=False)
+    monkeypatch.setattr(os.path, "isdir", lambda p: False)
+    for ram in (16.0, 64.0):
+        monkeypatch.setattr(cli, "_detect_ram_gb", lambda ram=ram: ram)
+        model, why = cli._pick_model("9b")
+        check(f"--model 9b -> 9B at {ram} GB", model == cli._HF_9B, model)
+        check("--model 9b reason names source", "--model" in why, why)
+    check("forcing 9B never warns", capsys.readouterr().err == "")
+
+
+def test_pick_model_flag_35b_big_no_warn(monkeypatch, capsys):
+    # Forcing 35B on a big box is exactly what the RAM pick would do -> no warning.
+    monkeypatch.delenv("CHAD_MODEL", raising=False)
+    monkeypatch.setattr(os.path, "isdir", lambda p: False)
+    monkeypatch.setattr(cli, "_detect_ram_gb", lambda: 64.0)
+    model, why = cli._pick_model("35b")
+    check("--model 35b -> 35B HF repo", model == cli._HF_35B, model)
+    check("35B on big box does not warn", capsys.readouterr().err == "")
+
+
+def test_pick_model_flag_35b_small_warns(monkeypatch, capsys):
+    # Forcing 35B under the RAM threshold still honors the override BUT warns (2A): the
+    # harness advises, the caller decides.
+    monkeypatch.delenv("CHAD_MODEL", raising=False)
+    monkeypatch.setattr(os.path, "isdir", lambda p: False)
+    monkeypatch.setattr(cli, "_detect_ram_gb", lambda: 16.0)
+    model, _ = cli._pick_model("35b")
+    check("--model 35b honored on small box", model == cli._HF_35B, model)
+    err = capsys.readouterr().err
+    check("small-box 35B warns", "35b forced" in err, err)
+    check("warning names the OOM risk", "OOM" in err, err)
+
+
+def test_pick_model_flag_35b_ram_none_warns(monkeypatch, capsys):
+    # RAM undetectable + forced 35B: warn (we can't vouch for the memory) and proceed.
+    monkeypatch.delenv("CHAD_MODEL", raising=False)
+    monkeypatch.setattr(os.path, "isdir", lambda p: False)
+    monkeypatch.setattr(cli, "_detect_ram_gb", lambda: None)
+    model, _ = cli._pick_model("35b")
+    check("--model 35b honored on unknown RAM", model == cli._HF_35B, model)
+    check("unknown-RAM 35B warns 'undetectable'",
+          "undetectable" in capsys.readouterr().err)
+
+
+def test_pick_model_flag_repo_passthrough(monkeypatch):
+    # A non-alias value is a literal repo id / local dir, passed through unchanged (the
+    # CLI twin of CHAD_MODEL). RAM is irrelevant.
+    monkeypatch.delenv("CHAD_MODEL", raising=False)
+    monkeypatch.setattr(cli, "_detect_ram_gb", lambda: 8.0)
+    model, why = cli._pick_model("/some/local/model")
+    check("--model repo passthrough", model == "/some/local/model", model)
+    check("passthrough reason names source + override",
+          "--model" in why and "override" in why.lower(), why)
+
+
+def test_pick_model_flag_beats_env(monkeypatch):
+    # Both set -> the CLI flag wins over CHAD_MODEL.
+    monkeypatch.setenv("CHAD_MODEL", "/env/repo")
+    monkeypatch.setattr(os.path, "isdir", lambda p: False)
+    monkeypatch.setattr(cli, "_detect_ram_gb", lambda: 64.0)
+    model, why = cli._pick_model("9b")
+    check("--model beats CHAD_MODEL", model == cli._HF_9B, model)
+    check("winner reason names --model", "--model" in why, why)
+
+
+def test_pick_model_flag_prefers_local_dir(monkeypatch):
+    # A forced size prefers the locally-built dir, same as the RAM path.
+    monkeypatch.delenv("CHAD_MODEL", raising=False)
+    monkeypatch.setattr(cli, "_detect_ram_gb", lambda: 64.0)
+    monkeypatch.setattr(os.path, "isdir", lambda p: p == cli._LOCAL_35B)
+    model, _ = cli._pick_model("35b")
+    check("forced 35B prefers local dir", model == cli._LOCAL_35B, model)
+
+
+def test_pick_model_default_equals_auto(monkeypatch):
+    # Regression lock for bench.py's no-arg callers: _pick_model() must behave exactly
+    # like _pick_model("auto") for a fixed environment.
+    monkeypatch.delenv("CHAD_MODEL", raising=False)
+    monkeypatch.setattr(os.path, "isdir", lambda p: False)
+    monkeypatch.setattr(cli, "_detect_ram_gb", lambda: 64.0)
+    check("no-arg == auto", cli._pick_model() == cli._pick_model("auto"))
+
+
 def test_ram_aware_ctx_limit():
     GB = 1e9
     # Measured 24 GB M4 Pro numbers: 19.07 GB working set, 12.06 GB resident after


### PR DESCRIPTION
## What

Adds a launch-time `--model` flag that overrides chad's RAM-aware model pick. Framed as an **override, not a picker** — the harness still picks well by default; this is the escape hatch.

```bash
uv run chad --model 9b      # force the small model (~5 GB) regardless of RAM
uv run chad --model 35b     # force the big model; warns first if RAM looks too small
uv run chad --model auto    # explicit RAM-aware pick (ignores CHAD_MODEL if set)
uv run chad --model <repo>  # any HF repo id / local dir
```

`--model` is the CLI twin of `CHAD_MODEL` (same value grammar) and **wins over it** when both are set. Precedence: `--model` → `CHAD_MODEL` → RAM-aware default. Launch-time only, nothing persisted — not a model picker.

## Why

Today the only override is `CHAD_MODEL`, which needs the full HF repo string. `--model 9b`/`35b` makes the common "force a size" case ergonomic and discoverable via `--help`, without adding a persistence surface or a runtime switch.

## Notes

- **RAM footgun handled:** forcing `35b` under the ~32 GB threshold (or on undetectable RAM) is honored but prints a one-line OOM warning on stderr first — the harness advises, the caller decides.
- **Back-compatible:** `_pick_model(override=None)` keeps `bench.py`'s no-arg callers and the existing test stub working. Extracted `_resolve()` so the forced-size and RAM paths share the local-dir-preference logic.
- **`prove`** still pins the validated 9B; its notice now says `--model` is ignored there too.

## Tests

9 new tests in `tests/test_cli.py` cover every override path: auto-ignores-env, forced 9b (both RAM sides, no warn), forced 35b (big=no-warn / small=warn / RAM-None=warn), repo passthrough, CLI-beats-env precedence, local-dir preference, and a `_pick_model() == _pick_model("auto")` regression lock. All 16 existing model-selection tests still pass.

`ruff` and `mypy` clean on touched files. Full suite: 620 passed / 3 skipped; the one unrelated pre-existing failure (`test_engine.py::test_truncation_recovery_matches_fresh`) reproduces identically on `main` and touches no code in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)