### PR TITLE
Release/1.0.7

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -27,6 +27,28 @@ jobs:
         # The published `uvx chad-code` one-liner. `|| true` until the first release
         # exists on PyPI — drop it once `chad-code` is published.
         run: uvx chad-code --version || true
+      - name: Released artifact actually imports (PyPI)
+        # `--version`/`--help` exit inside argparse, so they can't see a module that only
+        # loads on the first turn. That is exactly how an upstream mcp major shipped a
+        # broken `uvx chad-code` past a green canary: the entrypoint printed, the first
+        # prompt traced back. Import every submodule, and treat a fired SDK guard as
+        # failure (graceful degradation is for users, not for the canary).
+        run: |
+          uv run --no-project --with chad-code python -c "
+          import importlib, pkgutil, sys, chad
+          bad = []
+          for m in pkgutil.walk_packages(chad.__path__, 'chad.'):
+              try:
+                  importlib.import_module(m.name)
+              except Exception as e:
+                  bad.append(f'{m.name}: {type(e).__name__}: {e}')
+          import chad.mcp, chad.mcp_oauth
+          bad += [f'{m.__name__}: MCP SDK unusable: {m._SDK_ERROR}'
+                  for m in (chad.mcp, chad.mcp_oauth) if m._SDK_ERROR]
+          for b in bad:
+              print('BROKEN', b)
+          sys.exit(1 if bad else 0)
+          "
       - name: Version stamp (for the failure-email breadcrumb)
         if: always()
         run: uvx --from 'git+https://github.com/nathansutton/chad' chad --version || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,35 @@ jobs:
           uv venv --python 3.11 /tmp/fresh
           VIRTUAL_ENV=/tmp/fresh uv pip install .
           /tmp/fresh/bin/chad --help
+      - name: Every module imports under the fresh resolve
+        # `chad --help` exits inside argparse, so it only proves the CLI module tree
+        # imports. Modules imported later — mcp/mcp_oauth on the first Agent, speech on
+        # /speech — were unguarded by this job, and a fresh resolve that pulled an
+        # incompatible SDK crashed on the first real run while CI stayed green. Walk and
+        # import EVERY submodule so any import-time break fails here instead of at a
+        # user's first prompt.
+        run: |
+          /tmp/fresh/bin/python -c "
+          import importlib, pkgutil, sys, chad
+          bad = []
+          for m in pkgutil.walk_packages(chad.__path__, 'chad.'):
+              try:
+                  importlib.import_module(m.name)
+              except Exception as e:
+                  bad.append(f'{m.name}: {type(e).__name__}: {e}')
+          for b in bad:
+              print('IMPORT FAILED', b)
+          # chad.mcp/mcp_oauth guard their SDK imports so a bad resolve degrades instead
+          # of killing the agent — which would also hide the break from the walk above.
+          # Assert the guard did NOT fire: in CI an unusable SDK is a failure, not a
+          # graceful degradation.
+          import chad.mcp, chad.mcp_oauth
+          for mod in (chad.mcp, chad.mcp_oauth):
+              if mod._SDK_ERROR:
+                  bad.append(f'{mod.__name__}: MCP SDK unusable: {mod._SDK_ERROR}')
+                  print('SDK GUARD FIRED', bad[-1])
+          sys.exit(1 if bad else 0)
+          "
 
   lock:
     # uv.lock must stay in sync with pyproject.toml. Pure metadata check — no MLX,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   lint:
     # ruff + mypy need no Apple Silicon (mypy runs with ignore_missing_imports, so the
-    # mlx/jedi/tree_sitter stubs never matter for type-checking) — run on the cheap Linux
+    # mlx/tree_sitter stubs never matter for type-checking) — run on the cheap Linux
     # runner like the `lock` job, not the ~10×-pricier macos-14.
     runs-on: ubuntu-latest
     steps:
@@ -60,6 +60,15 @@ jobs:
         run: uv run --python ${{ matrix.python }} pytest -q
       - name: CLI smoke (entrypoint imports + parses, no model)
         run: uv run --python ${{ matrix.python }} chad --help
+      - name: Live LSP gate (real pyright via uvx — the shipped precision path)
+        # The fast gate above already ran these permissively (skip when a server
+        # can't start). Here, on ONE matrix version, a startup failure FAILS:
+        # graceful degradation is for users, not for CI. Exercises spawn via uvx,
+        # the pyright settings/readiness quirks, refs/hover/diagnostics end to end.
+        if: matrix.python == '3.12'
+        env:
+          CHAD_LSP_LIVE_REQUIRED: "1"
+        run: uv run --python ${{ matrix.python }} pytest -q tests/test_lsp_live.py
 
   build:
     # Guards the public install path: `uvx --from git+https://… chad` resolves fresh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,46 @@ Notable, user-visible changes.
 
 ## [1.0.7] — 2026-07-29
 
+- **Precision code intelligence now ships in the base install.** `find_refs` /
+  `rename_symbol` precision used to live behind an optional `lsp` extra
+  (`serena-agent`, 33 transitive dependencies) that `uvx chad-code` never installed —
+  so every published install ran name-match only. chad now drives language servers
+  through its own ~350-line LSP client (`lspclient.py`) plus a declarative registry
+  (`lspservers.py`, the nvim-lspconfig shape): pyright via uvx (guaranteed present on
+  the uvx install path), the TypeScript 7 native LSP via npx, gopls / rust-analyzer /
+  clangd / solargraph / intelephense from PATH. Zero new Python dependencies; the
+  `lsp` extra and serena-agent are gone. Servers that would answer confidently-wrong
+  empties without project context (clangd without `compile_commands.json`, TS without
+  a `tsconfig`) are refused, keeping the honestly-labeled name-match fallback.
+- **Qualified symbol paths in every language.** `view_symbol("Engine/process")`,
+  `replace_symbol("Engine.process", …)` etc. now resolve the method — not a same-named
+  free function — in Python, TS/JS, Go, Rust, Java, Ruby, C#, PHP, Kotlin and C++
+  alike, via scope chains derived from tree-sitter spans (plus receiver/impl context
+  for Go/Rust/C++, whose methods don't nest lexically). This was Python-only via
+  jedi before; jedi is deleted and every language takes one code path (verified
+  against jedi on this repo: 230/230 span-identical). A qualified path whose
+  container doesn't match is now a miss instead of silently editing the bare name.
+- **Broken grammars fixed for 4 of 12 fixture languages.** First polyglot measurement
+  found the language pack ships NO tags query for TypeScript/TSX, a PHP query that
+  doesn't compile against the current grammar, C with no reference captures, and C++
+  missing out-of-class method definitions. chad now carries its own tags queries for
+  those (`repomap._TAGS_OVERRIDE`), pinned by a 12-language coverage test.
+- **Post-edit typecheck in the edit result.** When a language server is warm, every
+  edit/symbol-edit result appends the server's type errors (errors only, capped,
+  ~50 tokens) — a type error surfaces immediately instead of one failed test run
+  later. Edits never pay a cold server start (lever: `post_edit_diagnostics`).
+- **New `hover` tool.** The resolved type signature + docs of one symbol via the
+  language server — one line instead of opening the defining file.
+- **mcp 2.x, single code path.** The `mcp<2` cap (below) was serena-agent collateral;
+  with serena gone chad runs natively on mcp 2.0 (protocol 2026-07-28). The two
+  renames that fail silently through getattr defaults (`isError`→`is_error`,
+  `readOnlyHint`→`read_only_hint`) are each pinned by a test that fails on the 1.x
+  spelling.
 - **Fixes a broken install.** `uvx chad-code` (and any other fresh resolve) crashed on
   startup with `ImportError: cannot import name 'streamablehttp_client'`. The `mcp`
   dependency was unbounded, so a clean resolve picked up the SDK's 2.0 major, which
   removed the HTTP transport chad uses, moved to `httpx2`, and split the wire types into
-  a separate distribution. `mcp` is now capped below 2.0; porting to the new API is a
-  deliberate change, not something a resolver should do to you at install time.
+  a separate distribution. (The cap has since become the deliberate 2.x port above.)
 - **A broken MCP SDK can no longer take the agent down.** Every other MCP failure already
   degraded — a server that's missing, misconfigured, or crashing costs you its tools and
   nothing else — but the SDK import itself ran unguarded at `chad.mcp` load, which happens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,16 @@ Notable, user-visible changes.
   jedi before; jedi is deleted and every language takes one code path (verified
   against jedi on this repo: 230/230 span-identical). A qualified path whose
   container doesn't match is now a miss instead of silently editing the bare name.
-- **Broken grammars fixed for 4 of 12 fixture languages.** First polyglot measurement
-  found the language pack ships NO tags query for TypeScript/TSX, a PHP query that
-  doesn't compile against the current grammar, C with no reference captures, and C++
-  missing out-of-class method definitions. chad now carries its own tags queries for
-  those (`repomap._TAGS_OVERRIDE`), pinned by a 12-language coverage test.
+- **Broken grammars fixed for 4 of 12 fixture languages — and shell added outright.**
+  First polyglot measurement found the language pack ships NO tags query for
+  TypeScript/TSX, a PHP query that doesn't compile against the current grammar, C
+  with no reference captures, and C++ missing out-of-class method definitions. chad
+  now carries its own tags queries for those (`repomap._TAGS_OVERRIDE`), plus a new
+  bash query the pack never had: shell functions and top-level variables now appear
+  in `repo_map`/`overview`, `find_refs` finds invocations across scripts, and
+  `replace_symbol` edits a shell function by name — shell is the one surface nearly
+  every real repo (and 89 of 91 terminal-bench-2.1 tasks) contains. All pinned by a
+  13-language coverage test.
 - **Post-edit typecheck in the edit result.** When a language server is warm, every
   edit/symbol-edit result appends the server's type errors (errors only, capped,
   ~50 tokens) — a type error surfaces immediately instead of one failed test run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 Notable, user-visible changes.
 
+## [1.0.7] — 2026-07-29
+
+- **Fixes a broken install.** `uvx chad-code` (and any other fresh resolve) crashed on
+  startup with `ImportError: cannot import name 'streamablehttp_client'`. The `mcp`
+  dependency was unbounded, so a clean resolve picked up the SDK's 2.0 major, which
+  removed the HTTP transport chad uses, moved to `httpx2`, and split the wire types into
+  a separate distribution. `mcp` is now capped below 2.0; porting to the new API is a
+  deliberate change, not something a resolver should do to you at install time.
+- **A broken MCP SDK can no longer take the agent down.** Every other MCP failure already
+  degraded — a server that's missing, misconfigured, or crashing costs you its tools and
+  nothing else — but the SDK import itself ran unguarded at `chad.mcp` load, which happens
+  on every Agent. It's guarded now: an incompatible SDK means no MCP tools plus one
+  warning line in `/mcp`, and the rest of chad runs. Relatedly, `/mcp` no longer reports
+  "no MCP servers configured" when servers *are* configured but all failed — it shows the
+  warnings that explain why.
+- **CI now catches this class of break.** The fresh-resolve job and the weekly install
+  canary only ran `chad --help`, which exits inside argparse and never imports the modules
+  that load on the first turn. Both now import every `chad` submodule against a clean
+  resolve and fail if the MCP SDK guard fires.
+
 ## [1.0.6] — 2026-07-28
 
 - **Voice mode, all local.** `/speech` in the TUI turns on push-to-talk: ctrl-t opens the

--- a/benchmarks/ctxengine/measure.py
+++ b/benchmarks/ctxengine/measure.py
@@ -41,6 +41,7 @@ LANGS = {
     "kotlin": ("helper", "process", "run", "Engine", "Lib.kt", "App.kt"),
     "c": ("helper", "process", "run", "engine_process", "lib.c", "app.c"),
     "cpp": ("helper", "process", "run", "Engine", "lib.cpp", "app.cpp"),
+    "bash": ("helper", "process", "run", "engine_process", "lib.sh", "app.sh"),
 }
 
 

--- a/benchmarks/ctxengine/measure.py
+++ b/benchmarks/ctxengine/measure.py
@@ -1,0 +1,128 @@
+"""Context-economy metric for the symbolic stack (plan: tokens-to-target).
+
+The symbolic stack is the context engine: its quality is how many tokens of tool
+output the model must ingest to reach a correct edit. For each polyglot fixture
+language this measures three fixed navigation tasks:
+
+  qualified  resolve the Engine method whose bare name collides with a free
+             function ("Engine/process"). One tool result if qualified paths
+             resolve; a disambiguation listing + a second call if they don't.
+  refs       find_refs on the cross-file helper: precise (language server) or
+             name-match, and how many tokens the listing costs.
+  navigate   find_symbol(helper) then view_symbol(run): the basic read loop.
+
+Tokens use repomap._estimate_tokens, the same accounting the map budgets with, so
+numbers are comparable to repo_map's own budget. No model load, no network.
+
+Run: uv run python benchmarks/ctxengine/measure.py [--json]
+"""
+
+import json
+import os
+import sys
+import time
+
+from chad.repomap import RepoMap, _estimate_tokens
+
+FIXTURES = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        os.pardir, os.pardir, "tests", "fixtures", "polyglot")
+
+# lang -> (helper, collider, caller, container, lib file, app file)
+LANGS = {
+    "python": ("helper", "process", "run", "Engine", "lib.py", "app.py"),
+    "typescript": ("helper", "process", "run", "Engine", "lib.ts", "app.ts"),
+    "javascript": ("helper", "process", "run", "Engine", "lib.js", "app.js"),
+    "go": ("Helper", "Process", "Run", "Engine", "lib.go", "app.go"),
+    "rust": ("helper", "process", "run", "Engine", "lib.rs", "app.rs"),
+    "java": ("helper", "process", "run", "Engine", "Engine.java", "App.java"),
+    "ruby": ("helper", "process", "run", "Engine", "lib.rb", "app.rb"),
+    "csharp": ("Helper", "Process", "Run", "Engine", "Lib.cs", "App.cs"),
+    "php": ("helper", "process", "run", "Engine", "lib.php", "app.php"),
+    "kotlin": ("helper", "process", "run", "Engine", "Lib.kt", "App.kt"),
+    "c": ("helper", "process", "run", "engine_process", "lib.c", "app.c"),
+    "cpp": ("helper", "process", "run", "Engine", "lib.cpp", "app.cpp"),
+}
+
+
+def _task_qualified(rm, names):
+    """Reach the Engine method's body via its qualified name. If the first call
+    comes back as a disambiguation listing, a real model must read it and issue a
+    second, path-qualified call — both count."""
+    helper, collider, run, container, lib, app = names
+    calls, tokens = 0, 0
+    out = rm.view_symbol(f"{container}/{collider}")
+    calls += 1
+    tokens += _estimate_tokens(out)
+    resolved_directly = "disambiguate" not in out and "not found" not in out
+    if not resolved_directly:
+        out = rm.view_symbol(collider, path=os.path.join(rm.root, lib))
+        calls += 1
+        tokens += _estimate_tokens(out)
+    ok = f"{lib}:" in out
+    return {"tokens": tokens, "calls": calls, "qualified_resolves": resolved_directly,
+            "ok": ok}
+
+
+def _task_refs(rm, names):
+    helper = names[0]
+    out = rm.find_refs(helper)
+    precise = "NAME-MATCH" not in out and "reference" in out
+    ok = names[5] in out
+    return {"tokens": _estimate_tokens(out), "calls": 1, "precise": precise, "ok": ok}
+
+
+def _task_navigate(rm, names):
+    helper, _collider, run, _container, lib, app = names
+    t1 = rm.find_symbol(helper)
+    t2 = rm.view_symbol(run)
+    ok = lib in t1 and t2.startswith(f"{app}:")
+    return {"tokens": _estimate_tokens(t1) + _estimate_tokens(t2), "calls": 2, "ok": ok}
+
+
+def measure(lang):
+    names = LANGS[lang]
+    rm = RepoMap(os.path.join(FIXTURES, lang))
+    rm._disk_checked = True  # hermetic: never touch the user's real tags cache
+    t0 = time.monotonic()
+    row = {"lang": lang,
+           "qualified": _task_qualified(rm, names),
+           "refs": _task_refs(rm, names),
+           "navigate": _task_navigate(rm, names)}
+    row["wall_ms"] = int((time.monotonic() - t0) * 1000)
+    row["tokens_total"] = sum(row[t]["tokens"] for t in ("qualified", "refs", "navigate"))
+    return row
+
+
+class _NoLsp:
+    """Hermetic stand-in: the metric accounts tool-output tokens, and must not
+    spawn real language servers (network, uvx/npx fetches, per-machine variance).
+    The `precise?` column therefore reports the no-server fallback labeling; the
+    live precision path is validated separately by tests/test_lsp_live.py."""
+
+    def references(self, *a, **k):
+        return None
+
+    def references_decorative(self, *a, **k):
+        return None
+
+
+def main():
+    from chad import lsp
+    lsp.service = lambda: _NoLsp()
+    rows = [measure(lang) for lang in sorted(LANGS)]
+    if "--json" in sys.argv:
+        print(json.dumps(rows, indent=2))
+        return
+    print(f"{'lang':<12}{'tok(qual)':>10}{'calls':>6}{'qual?':>7}{'tok(refs)':>10}"
+          f"{'precise?':>9}{'tok(nav)':>9}{'total':>7}{'ms':>5}  all-ok")
+    for r in rows:
+        q, f, n = r["qualified"], r["refs"], r["navigate"]
+        ok = all(x["ok"] for x in (q, f, n))
+        print(f"{r['lang']:<12}{q['tokens']:>10}{q['calls']:>6}"
+              f"{str(q['qualified_resolves']):>7}{f['tokens']:>10}"
+              f"{str(f['precise']):>9}{n['tokens']:>9}{r['tokens_total']:>7}"
+              f"{r['wall_ms']:>5}  {ok}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/design.md
+++ b/docs/design.md
@@ -160,12 +160,15 @@ each phase is good at:
   every definition with a built-in PageRank over the file→symbol reference graph;
   `overview` / `find_symbol` / `view_symbol` / `find_refs` read one symbol at a time. This
   is the cheap, always-available skeleton.
-- **Precision (solidlsp/pyright, `lsp.py`).** Semantic resolution that name-matching
-  *cannot* give: true go-to-definition, and cross-file find-all-references that follow
-  imports, respect scoping, and don't confuse a method with an unrelated function of the
-  same name. We drive Serena's synchronous LSP core directly — **no MCP server, no Serena
-  agent** — spawning pyright on a worker thread (~0.3 s warm), started **lazily** on first
-  use and bound to one project root.
+- **Precision (chad's own LSP client, `lspclient.py` + `lspservers.py` + `lsp.py`).**
+  Semantic resolution that name-matching *cannot* give: true go-to-definition,
+  cross-file find-all-references that follow imports, respect scoping, and don't
+  confuse a method with an unrelated function of the same name, hover types, and
+  post-edit typecheck diagnostics. The client is ~350 lines of chad-owned JSON-RPC
+  with zero language knowledge; which server speaks for which language is *data* in
+  `lspservers.py` (the nvim-lspconfig shape) — pyright via uvx for Python, the
+  TypeScript 7 native LSP via npx, gopls / rust-analyzer / clangd from PATH. Servers
+  start **lazily** on first use, bound to one project root.
 
 Why each of those earns its place specifically on a *small* model:
 
@@ -184,12 +187,14 @@ Why each of those earns its place specifically on a *small* model:
   call sites is a broken build, and a small model doing it by grep+edit *will* miss one.
   `rename_symbol` follows scope and renames every site or none.
 
-**Never a hard dependency.** The precision layer ships as the optional `lsp` extra
-(`serena-agent`, which contains solidlsp): `uv sync --extra lsp`; a default install
-runs entirely on tree-sitter. And even with the extra
-installed, if the language server can't start — no Node, offline, unsupported language —
-every caller falls back to the tree-sitter backend. Python is the proven backend
-(pyright); the other languages light up automatically once their server is available. The
+**Ships by default, never a hard dependency.** The precision layer is in the base
+install — no extra, no vendored language server. `uvx chad-code` itself proves uv is
+installed, so Python precision (pyright via `uvx`) works on the primary install path
+with zero configuration; other languages light up when their server is on PATH or
+fetchable via npx. If a server can't start — no Node, offline, unsupported language,
+or a project missing its honesty gate (a C++ tree without `compile_commands.json`, a
+TS tree without a `tsconfig`) — every caller falls back to the tree-sitter backend,
+which labels its references NAME-MATCH ONLY instead of lying with confidence. The
 LSP is a precision *upgrade*, and the harness runs fine without it.
 
 The honest payoff is **reliability, not raw prefill savings**. On a small repo a capable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # import name, and command name are independent. `uvx chad-code` runs the alias
 # script added under [project.scripts].
 name = "chad-code"
-version = "1.0.6"
+version = "1.0.7"
 description = "Local MLX-backed, Claude-Code-style coding agent (Apple Silicon, Ornith 35B/9B)"
 readme = "README.md"
 license = "MIT"
@@ -63,10 +63,16 @@ dependencies = [
     # wheel, zero transitive deps. Benchmarked vs scipy/networkx/igraph on a real
     # 421k-edge graph: identical top-50 ranking, 0.79s -> 0.04s.
     "rustworkx>=0.15",
-    # Floor lowered from 1.28.1: serena-agent (the `lsp` extra) hard-pins mcp==1.27.0, and
+    # Floor lowered from 1.28.1: serena-agent (the `lsp` extra) hard-pins one exact mcp
+    # (==1.27.0 then, ==1.28.1 as of serena 1.6.1), and
     # chad's mcp surface (ClientSession, stdio/streamable-http clients, OAuthClientProvider)
     # is stable across 1.27+. The 1.27->1.28 delta is only deprecations chad doesn't touch.
-    "mcp>=1.27",
+    # Capped below 2.0: it drops the deprecated `streamablehttp_client` (mcp.py's HTTP
+    # transport, the only entry point that takes headers=/auth= directly), swaps httpx for
+    # httpx2, and splits the wire types into a separate `mcp_types` distribution. An
+    # unpinned resolve pulled 2.0.0 and every fresh install died on the import. Migrating
+    # is a deliberate change, not a resolver accident — lift this cap with the port.
+    "mcp>=1.27,<2",
 ]
 
 # Optional syntax highlighting in diffs / confirm previews. Pure-Python,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ dependencies = [
     # `chad prove` 4/4); staying open keeps 2.x-floored ASR deps adoptable.
     "numpy>=1.26,<3",
     "huggingface-hub>=1.22.0", # first-run model download (cli.py/engine.py); imported directly, not just transitively
-    "jedi>=0.19.2", # in-process symbolic code intelligence (read/search/edit)
     "prompt_toolkit>=3.0.43",
     "tree-sitter>=0.26.0",
     "tree-sitter-language-pack>=1.12.2",
@@ -63,16 +62,14 @@ dependencies = [
     # wheel, zero transitive deps. Benchmarked vs scipy/networkx/igraph on a real
     # 421k-edge graph: identical top-50 ranking, 0.79s -> 0.04s.
     "rustworkx>=0.15",
-    # Floor lowered from 1.28.1: serena-agent (the `lsp` extra) hard-pins one exact mcp
-    # (==1.27.0 then, ==1.28.1 as of serena 1.6.1), and
-    # chad's mcp surface (ClientSession, stdio/streamable-http clients, OAuthClientProvider)
-    # is stable across 1.27+. The 1.27->1.28 delta is only deprecations chad doesn't touch.
-    # Capped below 2.0: it drops the deprecated `streamablehttp_client` (mcp.py's HTTP
-    # transport, the only entry point that takes headers=/auth= directly), swaps httpx for
-    # httpx2, and splits the wire types into a separate `mcp_types` distribution. An
-    # unpinned resolve pulled 2.0.0 and every fresh install died on the import. Migrating
-    # is a deliberate change, not a resolver accident — lift this cap with the port.
-    "mcp>=1.27,<2",
+    # Single 2.x code path (the 1.x cap left with serena-agent, which hard-pinned mcp
+    # and was the only thing keeping chad below 2). The 1->2 port was done deliberately,
+    # not by a resolver: two of the renames (isError->is_error, readOnlyHint->
+    # read_only_hint) FAIL SILENTLY through getattr defaults, so both are pinned by
+    # tests that would fail on the old attribute names (tests/test_mcp.py). 2.0 also
+    # negotiates protocol 2026-07-28; the 1.x line tops out at 2025-11-25. Capped <3:
+    # the same class of break will happen again.
+    "mcp>=2,<3",
 ]
 
 # Optional syntax highlighting in diffs / confirm previews. Pure-Python,
@@ -82,11 +79,6 @@ dependencies = [
 # package. Document uv/git installs only.
 [project.optional-dependencies]
 highlight = ["pygments>=2.17"]
-# Precision code intelligence (docs/design.md "Precision" phase): solidlsp ships inside
-# serena-agent and backs lsp.py's find-refs/rename via pyright. Optional on purpose —
-# heavyweight tree; absent, every caller falls back to the tree-sitter backend.
-# Install with `uv sync --extra lsp`.
-lsp = ["serena-agent>=1.5"]
 # Voice mode (/speech in the TUI): push-to-talk dictation via chad's vendored
 # Parakeet-on-MLX (src/chad/parakeet — the PyPI parakeet-mlx drags librosa's
 # numba/scipy tree for one mel-filterbank call) + spoken replies via macOS
@@ -159,7 +151,7 @@ ignore = ["E741"]  # ambiguous var names (l/I) appear in existing math code
 [tool.mypy]
 python_version = "3.11"
 files = ["src/chad"]
-ignore_missing_imports = true   # mlx/jedi/tree_sitter/mcp ship partial or no stubs
+ignore_missing_imports = true   # mlx/tree_sitter/mcp ship partial or no stubs
 warn_unused_ignores = true
 implicit_optional = true        # `x: T = None` defaults are idiomatic throughout; this
                                 # restores the pre-PEP-484 reading rather than rewriting

--- a/src/chad/__init__.py
+++ b/src/chad/__init__.py
@@ -4,7 +4,7 @@ A flat collection of cooperating modules behind one console script (``chad``):
 the inference engine, the tool layer, the agent loop, and the terminal UI.
 """
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 # chad sets no MLX_* runtime vars. MLX_METAL_FAST_SYNCH, MLX_MAX_OPS_PER_BUFFER
 # and MLX_MAX_MB_PER_BUFFER were each measured end-to-end on the 35B and every

--- a/src/chad/levers.py
+++ b/src/chad/levers.py
@@ -446,6 +446,17 @@ LEVERS: dict[str, Lever] = {
         "a flat file listing, so the model orients without a reflexive step-1 repo_map "
         "call. Degrades to the flat listing when repomap is unavailable (see prompt.py).",
         "ai-codex"),
+
+    # --- group "ctxengine": the uniform-symbols work. -------------------------------
+    "post_edit_diagnostics": Lever(
+        "Append the language server's post-edit typecheck errors (~50 tokens, errors "
+        "only, capped) to edit/symbol-edit results — the semantic tier above "
+        "syntaxgate's parse check. A type error surfaced in the edit result replaces "
+        "the multi-thousand-token failed test run the model would otherwise need to "
+        "discover it. Never spawns a server (an edit must not pay a cold start): "
+        "only a server already warmed by find_refs/hover/disambiguation is "
+        "consulted; absent one, silence.",
+        "ctxengine"),
 }
 
 

--- a/src/chad/lsp.py
+++ b/src/chad/lsp.py
@@ -1,20 +1,17 @@
-"""Precise cross-file code intelligence via an in-process language server.
+"""Precise cross-file code intelligence via language servers chad drives itself.
 
 Phase 2 of the symbolic stack. Tree-sitter (`repomap.py`) gives fast, language-
 agnostic STRUCTURE; this adds semantic PRECISION that name-matching cannot:
-true go-to-definition resolution and cross-file find-all-references that follow
-imports, respect scoping, and don't confuse a method with an unrelated function of
-the same name.
+true go-to-definition, cross-file find-all-references that follow imports and
+respect scoping, hover types, and post-edit diagnostics.
 
-We drive `solidlsp` (Serena's synchronous LSP core) directly — no MCP server, no
-Serena agent. For Python it spawns pyright on a worker thread (≈0.3s warm; a
-one-time pyright download on a cold machine). The server is started LAZILY on first
-use (so sessions that never ask for references pay nothing), bound to one project
-root, and reaped on rebind / process exit.
-
-Everything degrades gracefully: if the language server can't start (no Node,
-offline, unsupported language) callers fall back to the tree-sitter backend. The
-LSP is a precision upgrade, never a hard dependency of the harness.
+The transport is chad's own `lspclient.py` (generic JSON-RPC, zero language
+knowledge); which server speaks for which language is data in `lspservers.py`.
+This module is POLICY: servers start LAZILY on first use (a session that never
+asks for references pays nothing), are bound to one project root, degrade to the
+tree-sitter fallback on any failure, and are reaped on rebind / process exit.
+Precision ships in the base install — no extra, no vendored language server; a
+missing server on PATH degrades per-language, never breaks the harness.
 
 Operational guardrails (all measured on an 11k-file repo before they existed):
 * every request carries a timeout (default 5s; one uncapped find-references ran 18s),
@@ -24,7 +21,8 @@ Operational guardrails (all measured on an 11k-file repo before they existed):
   request (pyright hit 4 GB on hot symbols — on a machine wiring ~12 GB of model
   weights that's the same Metal-OOM crash class the repo map fix removed), and
 * decorative callers (disambiguation hints) use `references_decorative`, which
-  never *starts* a server except the proven-cheap Python backend.
+  never *starts* a server unless the registry marks it `decorative_ok`
+  (measured: one view_symbol('main') spawned clangd per candidate: 86s).
 """
 
 import atexit
@@ -33,76 +31,23 @@ import subprocess
 import threading
 from collections import defaultdict
 
-from . import config
+from . import config, lspservers
 from .diag import log
-
-# solidlsp pulls a fair bit of machinery; import lazily inside _server() so a normal
-# session / cold start doesn't pay for it unless references are actually requested.
-# It ships in the optional `lsp` extra (serena-agent) — absent, we log once and every
-# caller degrades to the tree-sitter backend.
-
-_MISSING_LOGGED = False
-
-_IGNORED = ["__pycache__", ".git", ".venv", "venv", "node_modules", ".mypy_cache",
-            ".pytest_cache", "dist", "build", ".cache", "models"]
-
-# Extension -> solidlsp Language enum name. Python is the proven backend (pyright);
-# the others light up automatically once their language server is available.
-_LANG_BY_EXT = {
-    ".py": "PYTHON", ".pyi": "PYTHON",
-    ".ts": "TYPESCRIPT", ".tsx": "TYPESCRIPT", ".js": "TYPESCRIPT", ".jsx": "TYPESCRIPT",
-    ".go": "GO", ".rs": "RUST", ".java": "JAVA", ".rb": "RUBY",
-    ".cs": "CSHARP", ".php": "PHP", ".kt": "KOTLIN", ".cpp": "CPP", ".cc": "CPP",
-    ".c": "CPP", ".h": "CPP", ".hpp": "CPP",
-}
-
-
-def lang_for(path: str):
-    return _LANG_BY_EXT.get(os.path.splitext(path)[1].lower())
-
+from .lspservers import lang_for  # re-export: the service keys requests off it
 
 _REQUEST_TIMEOUT_S = config.env_float("CHAD_LSP_TIMEOUT", 5.0)
+_INIT_TIMEOUT_S = config.env_float("CHAD_LSP_INIT_TIMEOUT", 30.0)
+_DIAG_TIMEOUT_S = config.env_float("CHAD_LSP_DIAG_TIMEOUT", 3.0)
 _MAX_RSS_MB = config.env_int("CHAD_LSP_MAX_RSS_MB", 1536)
 
-# Languages worth a server *start* for a decorative annotation. Python's pyright is
-# proven lazy and cheap (~0.9s spawn, flat across repo sizes); other servers can
-# gradle-sync, download binaries, or chew a file for ~10s (measured: clangd), which
-# is never worth a "used by …" hint.
-_DECOR_SPAWN = frozenset({"PYTHON"})
 
-
-def _has_compile_db(root: str) -> bool:
-    """clangd is only precise with a compilation database; without one it silently
-    analyzes each file in isolation and returns clean empty cross-file results."""
-    return any(os.path.exists(os.path.join(root, p))
-               for p in ("compile_commands.json",
-                         os.path.join("build", "compile_commands.json"),
-                         ".clangd"))
-
-
-_QUIET_HOOK_INSTALLED = False
-
-
-def _install_quiet_shutdown_hook():
-    """solidlsp sends the LSP shutdown request from a helper thread; when the server
-    is busy (typically mid-request after we timed one out) that request itself times
-    out and the default threading excepthook dumps a full traceback over the TUI.
-    Filter exactly that case — solidlsp still reaps the process — and pass every
-    other thread exception through untouched."""
-    global _QUIET_HOOK_INSTALLED
-    if _QUIET_HOOK_INSTALLED:
-        return
-    _QUIET_HOOK_INSTALLED = True
-    prev = threading.excepthook
-
-    def hook(args):
-        if (args.exc_type is TimeoutError
-                and "_send_shutdown" in getattr(args.thread, "name", "")):
-            log.info("lsp: shutdown request timed out (server busy); reaped anyway")
-            return
-        prev(args)
-
-    threading.excepthook = hook
+def _gate_open(spec, root: str) -> bool:
+    """The registry's honesty gate: some servers (clangd without a compile
+    database, TS without a tsconfig — both measured) return confidently EMPTY
+    cross-file results when the project context is missing. If the row names
+    project files, one must exist or the server is not started at all."""
+    return not spec.project_gate or any(
+        os.path.exists(os.path.join(root, p)) for p in spec.project_gate)
 
 
 def _tree_rss_mb(pid: int) -> int:
@@ -133,91 +78,146 @@ def _tree_rss_mb(pid: int) -> int:
 
 
 class LspService:
-    """One language server per (root, language), started lazily, reaped on exit."""
+    """One language-server process per (root, server_key) — servers that speak
+    several languages (tsserver: ts+js; clangd: c+cpp) share one — started
+    lazily, reaped on exit."""
 
     def __init__(self, root: str = "."):
         self.root = os.path.abspath(root)
-        self._servers = {}            # lang -> SolidLanguageServer | None (None = tried & failed)
+        self._servers = {}    # server_key -> LspClient | None (None = tried & failed)
         self._lock = threading.Lock()
 
-    def _server(self, lang: str):
-        """Lazily create + start the language server for `lang`; None if unavailable.
-        A failed start is remembered (cached None) so we don't retry on every call."""
-        if lang in self._servers:
-            return self._servers[lang]
-        with self._lock:
-            if lang in self._servers:
-                return self._servers[lang]
-            if lang == "CPP" and not _has_compile_db(self.root):
-                # Without a compile database clangd "works" but sees each file in
-                # isolation: cross-file references come back a clean, WRONG empty.
-                # Refusing to start keeps callers on the tree-sitter fallback, which
-                # labels itself NAME-MATCH ONLY instead of lying with confidence.
-                log.info("lsp: no compile_commands.json under %s; not starting clangd "
-                         "(tree-sitter fallback)", self.root)
-                self._servers[lang] = None
-                return None
-            srv = None
-            try:
-                from solidlsp import SolidLanguageServer
-                from solidlsp.ls_config import Language, LanguageServerConfig
-                from solidlsp.settings import SolidLSPSettings
-            except ImportError:
-                global _MISSING_LOGGED
-                if not _MISSING_LOGGED:
-                    _MISSING_LOGGED = True
-                    log.info("lsp: solidlsp not installed (install the 'lsp' extra for "
-                             "precise refs/rename); using tree-sitter fallback")
-                self._servers[lang] = None
-                return None
-            try:
-                _install_quiet_shutdown_hook()
-                cfg = LanguageServerConfig(code_language=Language[lang],
-                                           ignored_paths=list(_IGNORED))
-                srv = SolidLanguageServer.create(cfg, self.root,
-                                                 solidlsp_settings=SolidLSPSettings())
-                srv.start()
-                # A hung/slow request must degrade to the tree-sitter fallback, not
-                # stall the agent loop (measured 18s for one uncapped find-references).
-                try:
-                    srv.set_request_timeout(_REQUEST_TIMEOUT_S)
-                except Exception:  # noqa: BLE001 - older solidlsp without the knob
-                    pass
-            except Exception:
-                srv = None
-            self._servers[lang] = srv
-            return srv
+    # -- lifecycle ---------------------------------------------------------
 
-    def _recycle_if_bloated(self, lang: str, srv):
+    def _server(self, spec):
+        """Lazily create + start the language server for `spec`; None if
+        unavailable. A failed start is remembered (cached None) — no per-call retry."""
+        key = spec.server_key
+        if key in self._servers:
+            return self._servers[key]
+        with self._lock:
+            if key in self._servers:
+                return self._servers[key]
+            cli = None
+            if not spec.commands:
+                log.info("lsp: %s has no supported server (%s); tree-sitter fallback",
+                         spec.language, spec.unsupported)
+            elif not _gate_open(spec, self.root):
+                # e.g. clangd without compile_commands.json, TS without a tsconfig:
+                # the server would return clean, WRONG empties. Refusing keeps
+                # callers on the tree-sitter fallback, which labels itself
+                # NAME-MATCH ONLY instead of lying with confidence.
+                log.info("lsp: none of %s under %s; not starting %s "
+                         "(tree-sitter fallback)", spec.project_gate, self.root, key)
+            else:
+                cands = lspservers.resolve_commands(spec)
+                if not cands:
+                    log.info("lsp: no %s server available for %s (tier: %s); "
+                             "tree-sitter fallback", key, spec.language, spec.tier)
+                for cmd in cands:   # a candidate that fails to start must not
+                    cli = self._start(spec, cmd)   # block the next one
+                    if cli is not None:
+                        break
+            self._servers[key] = cli
+            return cli
+
+    def _start(self, spec, cmd):
+        from . import lspclient
+        cli = None
+        try:
+            cli = lspclient.LspClient(cmd, self.root)
+            cli.initialize(init_options={}, timeout=_INIT_TIMEOUT_S)
+            if spec.settings is not None:
+                # pyright asks for workspace/configuration but does not START
+                # analysis until settings are pushed (measured: refs hang forever
+                # on a client that only ever answers the pull)
+                cli.notify("workspace/didChangeConfiguration",
+                           {"settings": spec.settings})
+            if spec.ready_log:
+                # e.g. pyright answers references with a confident EMPTY list until
+                # its initial scan logs completion; asking earlier returns lies.
+                cli.wait_log(spec.ready_log, timeout=spec.ready_timeout_s)
+            return cli
+        except Exception as e:  # noqa: BLE001 - any start failure degrades cleanly
+            log.info("lsp: %s failed to start (%s); tree-sitter fallback",
+                     spec.server_key, e)
+            if cli is not None:
+                try:
+                    cli.shutdown()
+                except Exception:  # noqa: BLE001
+                    pass
+            return None
+
+    def _recycle_if_bloated(self, key, cli):
         """Stop and forget a server whose process tree outgrew the RSS cap. The next
         request simply starts a fresh one (pyright re-warms in ~2s) — unbounded
         analysis memory next to wired model weights is how the process dies."""
-        pid = getattr(getattr(getattr(srv, "server", None), "process", None), "pid", None)
-        if not pid:
-            return
-        mb = _tree_rss_mb(pid)
+        mb = _tree_rss_mb(cli.pid) if cli.pid else 0
         if mb > _MAX_RSS_MB:
-            log.info("lsp: %s server tree at %d MB (cap %d); recycling", lang, mb, _MAX_RSS_MB)
-            try:
-                srv.stop()
-            except Exception:  # noqa: BLE001 - reaping is best-effort
-                pass
-            with self._lock:
-                if self._servers.get(lang) is srv:
-                    del self._servers[lang]
+            log.info("lsp: %s server tree at %d MB (cap %d); recycling", key, mb,
+                     _MAX_RSS_MB)
+            self._drop(key, cli)
+
+    def _drop(self, key, cli):
+        try:
+            cli.shutdown()
+        except Exception:  # noqa: BLE001 - reaping is best-effort
+            pass
+        with self._lock:
+            if self._servers.get(key) is cli:
+                del self._servers[key]
 
     def stop(self):
-        for srv in self._servers.values():
-            if srv is not None:
+        for cli in self._servers.values():
+            if cli is not None:
                 try:
-                    srv.stop()
-                except Exception:
+                    cli.shutdown()
+                except Exception:  # noqa: BLE001
                     pass
         self._servers.clear()
 
     def available(self, path: str) -> bool:
-        lang = lang_for(path)
-        return bool(lang) and self._server(lang) is not None
+        spec = self._spec(path)
+        return spec is not None and self._server(spec) is not None
+
+    # -- requests ----------------------------------------------------------
+
+    def _spec(self, rel_path):
+        lang = lang_for(rel_path)
+        return lspservers.spec_for(lang) if lang else None
+
+    def _abs(self, rel_path):
+        return rel_path if os.path.isabs(rel_path) else os.path.join(self.root, rel_path)
+
+    def _rel(self, p):
+        try:
+            return os.path.relpath(p, self.root)
+        except ValueError:
+            return p
+
+    def _ask(self, rel_path, fn, timeout=None, sync=True):
+        """Common request plumbing: spec -> server -> didOpen -> fn(cli, abs, t),
+        degrading to None on any failure; RSS check + dead-server drop after.
+        `sync=False` leaves the didOpen/didChange to fn (diagnostics must read the
+        publish generation BEFORE syncing or it can miss its own publish)."""
+        spec = self._spec(rel_path)
+        if spec is None:
+            return None
+        cli = self._server(spec)
+        if cli is None:
+            return None
+        t = _REQUEST_TIMEOUT_S if timeout is None else min(timeout, _REQUEST_TIMEOUT_S)
+        ap = self._abs(rel_path)
+        try:
+            if sync:
+                cli.sync_doc(ap, spec.language_id)
+            return fn(cli, ap, t)
+        except Exception:  # noqa: BLE001 - timeout/protocol error/dead server
+            if not cli.alive():
+                self._drop(spec.server_key, cli)   # next request starts fresh
+            return None
+        finally:
+            self._recycle_if_bloated(spec.server_key, cli)
 
     def references(self, rel_path: str, name_row: int, name_col: int, timeout=None):
         """Precise references to the symbol whose identifier sits at the 0-based
@@ -226,80 +226,97 @@ class LspService:
         should fall back to tree-sitter). An empty list means "ran, found none".
         `timeout` tightens the request deadline below the default for callers with
         their own budget (the disambiguation pass); never loosens it."""
-        lang = lang_for(rel_path)
-        if not lang:
+        out = self._ask(rel_path,
+                        lambda cli, ap, t: cli.references(ap, name_row, name_col,
+                                                          timeout=t),
+                        timeout)
+        if out is None:
             return None
-        srv = self._server(lang)
-        if srv is None:
-            return None
-        set_to = getattr(srv, "set_request_timeout", None)
-        if timeout is not None and set_to is not None:
-            try:
-                set_to(min(timeout, _REQUEST_TIMEOUT_S))
-            except Exception:  # noqa: BLE001 - keep the default timeout
-                set_to = None
-        try:
-            locs = srv.request_references(rel_path, name_row, name_col)
-        except Exception:
-            return None
-        finally:
-            if timeout is not None and set_to is not None:
-                try:
-                    set_to(_REQUEST_TIMEOUT_S)
-                except Exception:  # noqa: BLE001
-                    pass
-            self._recycle_if_bloated(lang, srv)
-        out = []
-        for loc in locs or []:
-            rel = loc.get("relativePath")
-            if not rel:
-                uri = loc.get("uri", "")
-                rel = self._rel(uri[7:]) if uri.startswith("file://") else uri
-            start = loc.get("range", {}).get("start", {})
-            out.append((rel, start.get("line", 0) + 1, start.get("character", 0) + 1))
-        return out
+        return [(self._rel(p), ln, col) for p, ln, col in out]
 
     def references_decorative(self, rel_path: str, name_row: int, name_col: int,
                               timeout=None):
         """`references()` for decoration (the disambiguation "used by …" hints):
-        never pays a server *start* for it unless the language is the proven-cheap
-        Python backend — other languages are used only if already running. Measured
-        before this existed: one view_symbol('main') on a mixed repo spawned clangd
-        per C++ candidate and took 86s."""
-        lang = lang_for(rel_path)
-        if not lang:
+        never pays a server *start* unless the registry marks the server cheap
+        (`decorative_ok`) — others are used only if already running."""
+        spec = self._spec(rel_path)
+        if spec is None:
             return None
-        if lang not in _DECOR_SPAWN and self._servers.get(lang) is None:
+        if not spec.decorative_ok and self._servers.get(spec.server_key) is None:
             return None  # absent (never started) and tried-but-failed both refuse
         return self.references(rel_path, name_row, name_col, timeout=timeout)
 
     def definition(self, rel_path: str, row: int, col: int):
         """Precise go-to-definition for the symbol at 0-based (row, col). Returns a
         list of (rel, line1) or None if unavailable."""
-        lang = lang_for(rel_path)
-        if not lang:
+        out = self._ask(rel_path,
+                        lambda cli, ap, t: cli.definition(ap, row, col, timeout=t))
+        if out is None:
             return None
-        srv = self._server(lang)
-        if srv is None:
-            return None
-        try:
-            locs = srv.request_definition(rel_path, row, col)
-        except Exception:
-            return None
-        finally:
-            self._recycle_if_bloated(lang, srv)
-        out = []
-        for loc in locs or []:
-            rel = loc.get("relativePath") or loc.get("uri", "")
-            start = loc.get("range", {}).get("start", {})
-            out.append((rel, start.get("line", 0) + 1))
-        return out
+        return [(self._rel(p), ln) for p, ln in out]
 
-    def _rel(self, p):
-        try:
-            return os.path.relpath(p, self.root)
-        except ValueError:
-            return p
+    def hover(self, rel_path: str, row: int, col: int):
+        """Hover text (type signature / docs) for the symbol at 0-based (row, col),
+        or None if unavailable — the model reads a type in ~30 tokens instead of
+        opening the defining file."""
+        return self._ask(rel_path,
+                         lambda cli, ap, t: cli.hover(ap, row, col, timeout=t))
+
+    def diagnostics_after_edit(self, rel_path: str):
+        """The server's diagnostics for rel_path's CURRENT on-disk content — the
+        post-edit typecheck. Returns [(severity, line1, message)] (possibly empty:
+        a clean bill), or None when no server is WARM for this language. Stricter
+        than the decorative policy: an edit result is on the interactive path, so
+        it never pays a server start at all — not even a registry-cheap one (a
+        cold uvx fetch inside an edit round trip is exactly the stall the
+        decorative rule exists to prevent). The note lights up once find_refs /
+        hover / disambiguation has warmed the server."""
+        spec = self._spec(rel_path)
+        if spec is None:
+            return None
+        if self._servers.get(spec.server_key) is None:
+            return None
+        def ask(cli, ap, _t):
+            gen = cli.diag_generation(ap)     # BEFORE the sync that triggers analysis
+            cli.sync_doc(ap, spec.language_id)
+            try:
+                # pull first (LSP 3.17; synchronous, and unsupported servers refuse
+                # instantly) — TS7's native LSP never pushes at all
+                diags = cli.pull_diagnostics(ap, timeout=_DIAG_TIMEOUT_S)
+            except Exception:  # noqa: BLE001 - no pull support: wait for the push
+                diags = cli.wait_diagnostics(ap, gen, timeout=_DIAG_TIMEOUT_S)
+            if diags is None:
+                return None
+            sev_names = {1: "error", 2: "warning", 3: "info", 4: "hint"}
+            out = []
+            for d in diags:
+                start = (d.get("range") or {}).get("start") or {}
+                out.append((sev_names.get(d.get("severity", 1), "error"),
+                            start.get("line", 0) + 1, str(d.get("message", ""))))
+            return out
+        return self._ask(rel_path, ask, sync=False)
+
+
+def diagnostics_note(path: str) -> str:
+    """A compact post-edit typecheck note for edit-tool results, or "". Errors only
+    (warnings are style noise mid-edit), capped at 5, first line of each message —
+    ~50 tokens that can replace the failed test run the model would otherwise burn
+    to discover a type error. Empty when no server is warm for the language (see
+    diagnostics_after_edit's spawn policy) or diagnostics are disabled
+    (CHAD_LSP_DIAG_TIMEOUT=0)."""
+    if _DIAG_TIMEOUT_S <= 0:
+        return ""
+    try:
+        diags = service().diagnostics_after_edit(path)
+    except Exception:  # noqa: BLE001 - a diag failure must never break an edit result
+        return ""
+    errs = [(ln, msg) for sev, ln, msg in diags or [] if sev == "error"]
+    if not errs:
+        return ""
+    lines = [f"  line {ln}: {msg.splitlines()[0][:160]}" for ln, msg in errs[:5]]
+    more = f"\n  … (+{len(errs) - 5} more)" if len(errs) > 5 else ""
+    return (f"\n[typecheck — {len(errs)} error(s) (language server):\n"
+            + "\n".join(lines) + more + "]")
 
 
 _SERVICE = None

--- a/src/chad/lspclient.py
+++ b/src/chad/lspclient.py
@@ -1,0 +1,341 @@
+"""Generic LSP client: Content-Length JSON-RPC over stdio. Zero language knowledge.
+
+This is chad's own precision transport — the six-method surface we consumed from
+solidlsp (spawn, initialize, references, definition, timeout, shutdown) plus the
+two requests the context engine wants next (hover, publishDiagnostics), in one
+file with no dependencies beyond the standard library. Which server to spawn for
+which language, and how to tell when it is actually ready, is DATA and lives in
+`lspservers.py`; policy (timeouts, RSS recycling, decorative spawns, fallback to
+tree-sitter) stays in `lsp.py`.
+
+Wire mechanics, all per the LSP spec:
+* frames are `Content-Length: N\\r\\n\\r\\n` + N bytes of JSON, both directions;
+* a reader thread correlates responses to requests by id (each request gets an
+  Event; timeouts abandon the slot so a late response is dropped silently);
+* server→client REQUESTS (workspace/configuration, client/registerCapability,
+  window/workDoneProgress/create) must be answered or servers stall — we answer
+  neutrally (configuration gets [null]×items, the rest get null);
+* notifications we care about are recorded: window/logMessage into a ring buffer
+  (readiness probes grep it — see lspservers' pyright rule) and
+  textDocument/publishDiagnostics into a per-uri generation counter + payload so
+  a caller can wait for the diagnostics that follow ITS edit, not a stale set.
+"""
+
+import itertools
+import json
+import os
+import pathlib
+import re
+import subprocess
+import threading
+import time
+import urllib.parse
+import urllib.request
+from collections import deque
+
+from .diag import log
+
+
+class LspError(Exception):
+    """A request the server answered with an error, or a dead/unusable server."""
+
+
+def path_to_uri(path: str) -> str:
+    return pathlib.Path(os.path.abspath(path)).as_uri()
+
+
+def uri_to_path(uri: str) -> str:
+    return urllib.request.url2pathname(urllib.parse.urlparse(uri).path)
+
+
+class LspClient:
+    """One language-server process: spawn, handshake, request/notify, shutdown."""
+
+    def __init__(self, cmd, root: str):
+        self.root = os.path.abspath(root)
+        self.cmd = list(cmd)
+        self.proc = subprocess.Popen(
+            self.cmd, cwd=self.root, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL)
+        self._seq = itertools.count(1)
+        self._write_lock = threading.Lock()
+        self._pending = {}          # id -> (Event, slot dict)
+        self._pending_lock = threading.Lock()
+        self._cond = threading.Condition()   # guards _logs and _diags updates
+        self._logs = deque(maxlen=256)       # window/logMessage message strings
+        self._diags = {}            # uri -> (generation, [diagnostic dicts])
+        self._open_docs = {}        # uri -> version
+        self._reader = threading.Thread(target=self._read_loop, daemon=True,
+                                        name=f"lsp-read-{os.path.basename(self.cmd[0])}")
+        self._reader.start()
+
+    # -- wire --------------------------------------------------------------
+
+    def _send(self, payload: dict):
+        body = json.dumps(payload).encode()
+        frame = b"Content-Length: %d\r\n\r\n%s" % (len(body), body)
+        stdin = self.proc.stdin
+        try:
+            with self._write_lock:
+                assert stdin is not None   # Popen(stdin=PIPE) guarantees it
+                stdin.write(frame)
+                stdin.flush()
+        except Exception as e:
+            raise LspError(f"server unwritable: {e}") from e
+
+    def _read_loop(self):
+        stdout = self.proc.stdout
+        try:
+            while True:
+                length = None
+                while True:                    # headers until the blank line
+                    line = stdout.readline()
+                    if not line:
+                        raise EOFError
+                    if line in (b"\r\n", b"\n"):
+                        break
+                    if line.lower().startswith(b"content-length:"):
+                        length = int(line.split(b":", 1)[1].strip())
+                if length is None:
+                    continue
+                body = stdout.read(length)
+                if body is None or len(body) < length:
+                    raise EOFError
+                try:
+                    self._dispatch(json.loads(body))
+                except Exception:  # noqa: BLE001 - one bad frame must not kill the reader
+                    log.info("lsp: undispatchable frame from %s", self.cmd[0])
+        except Exception:  # noqa: BLE001 - EOF/kill: fail everything still waiting
+            with self._pending_lock:
+                pending, self._pending = self._pending, {}
+            for ev, slot in pending.values():
+                slot["error"] = {"message": "server exited"}
+                ev.set()
+
+    def _dispatch(self, msg: dict):
+        if "id" in msg and "method" in msg:      # server -> client request
+            self._answer_server_request(msg)
+        elif "method" in msg:                    # notification
+            params = msg.get("params") or {}
+            if msg["method"] == "window/logMessage":
+                with self._cond:
+                    self._logs.append(str(params.get("message", "")))
+                    self._cond.notify_all()
+            elif msg["method"] == "textDocument/publishDiagnostics":
+                uri = params.get("uri", "")
+                with self._cond:
+                    gen = self._diags.get(uri, (0, None))[0] + 1
+                    self._diags[uri] = (gen, params.get("diagnostics") or [])
+                    self._cond.notify_all()
+        elif "id" in msg:                        # response
+            with self._pending_lock:
+                ev_slot = self._pending.pop(msg["id"], None)
+            if ev_slot:                          # None: timed out, dropped
+                ev, slot = ev_slot
+                if "error" in msg:
+                    slot["error"] = msg["error"]
+                else:
+                    slot["result"] = msg.get("result")
+                ev.set()
+
+    def _answer_server_request(self, msg: dict):
+        # A server blocked on an unanswered request looks exactly like a hang.
+        result = None
+        if msg["method"] == "workspace/configuration":
+            items = (msg.get("params") or {}).get("items") or []
+            result = [None] * len(items)
+        try:
+            self._send({"jsonrpc": "2.0", "id": msg["id"], "result": result})
+        except LspError:
+            pass
+
+    # -- rpc ---------------------------------------------------------------
+
+    def request(self, method: str, params=None, timeout: float = 5.0):
+        rid = next(self._seq)
+        ev, slot = threading.Event(), {}
+        with self._pending_lock:
+            self._pending[rid] = (ev, slot)
+        self._send({"jsonrpc": "2.0", "id": rid, "method": method,
+                    "params": params or {}})
+        if not ev.wait(timeout):
+            with self._pending_lock:
+                self._pending.pop(rid, None)
+            raise TimeoutError(f"{method} timed out after {timeout:g}s")
+        if "error" in slot:
+            raise LspError(f"{method}: {slot['error'].get('message', slot['error'])}")
+        return slot.get("result")
+
+    def notify(self, method: str, params=None):
+        self._send({"jsonrpc": "2.0", "method": method, "params": params or {}})
+
+    @property
+    def pid(self):
+        return self.proc.pid
+
+    def alive(self) -> bool:
+        return self.proc.poll() is None
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def initialize(self, init_options=None, timeout: float = 30.0) -> dict:
+        uri = path_to_uri(self.root)
+        result = self.request("initialize", {
+            "processId": os.getpid(),
+            "rootUri": uri,
+            "rootPath": self.root,
+            "workspaceFolders": [{"uri": uri, "name": os.path.basename(self.root)}],
+            "initializationOptions": init_options or {},
+            "capabilities": {
+                "textDocument": {
+                    "synchronization": {"didSave": True},
+                    "references": {}, "definition": {},
+                    "hover": {"contentFormat": ["plaintext", "markdown"]},
+                    "publishDiagnostics": {},
+                    "diagnostic": {},   # pull model — TS7's native LSP never pushes
+                },
+                "workspace": {"workspaceFolders": True, "configuration": True},
+            },
+        }, timeout=timeout)
+        self.notify("initialized", {})
+        return result or {}
+
+    def shutdown(self):
+        try:
+            self.request("shutdown", timeout=2.0)
+        except Exception:  # noqa: BLE001 - a busy server still gets exit+kill below
+            pass
+        try:
+            self.notify("exit")
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            self.proc.wait(timeout=1.0)
+        except Exception:  # noqa: BLE001
+            self.proc.kill()
+
+    # -- documents ---------------------------------------------------------
+
+    def sync_doc(self, path: str, language_id: str, text=None) -> str:
+        """didOpen (first time) or full-text didChange (after) for `path`; returns
+        its uri. `text=None` reads the file — pass text to sync unsaved content.
+        Unchanged content is NOT re-sent (an agent re-reads hot files constantly;
+        redundant didChange floods make servers re-analyze for nothing)."""
+        if text is None:
+            with open(path, errors="replace") as f:
+                text = f.read()
+        uri = path_to_uri(path)
+        ver_hash = self._open_docs.get(uri)
+        if ver_hash is None:
+            self._open_docs[uri] = (1, hash(text))
+            self.notify("textDocument/didOpen", {"textDocument": {
+                "uri": uri, "languageId": language_id, "version": 1, "text": text}})
+        elif ver_hash[1] != hash(text):
+            ver = ver_hash[0] + 1
+            self._open_docs[uri] = (ver, hash(text))
+            self.notify("textDocument/didChange", {
+                "textDocument": {"uri": uri, "version": ver},
+                "contentChanges": [{"text": text}]})
+        return uri
+
+    # -- requests the context engine uses ---------------------------------
+
+    def references(self, path: str, row: int, col: int, timeout: float = 5.0,
+                   include_declaration: bool = False):
+        """[(abs_path, line1, col1)] for the symbol at 0-based (row, col)."""
+        uri = path_to_uri(path)
+        locs = self.request("textDocument/references", {
+            "textDocument": {"uri": uri},
+            "position": {"line": row, "character": col},
+            "context": {"includeDeclaration": include_declaration},
+        }, timeout=timeout)
+        return [self._loc(loc) for loc in locs or []]
+
+    def definition(self, path: str, row: int, col: int, timeout: float = 5.0):
+        """[(abs_path, line1)] — Location | Location[] | LocationLink[] normalized."""
+        res = self.request("textDocument/definition", {
+            "textDocument": {"uri": path_to_uri(path)},
+            "position": {"line": row, "character": col},
+        }, timeout=timeout)
+        if isinstance(res, dict):
+            res = [res]
+        return [self._loc(loc)[:2] for loc in res or []]
+
+    def hover(self, path: str, row: int, col: int, timeout: float = 5.0):
+        """Plain-text hover contents for (row, col), or None."""
+        res = self.request("textDocument/hover", {
+            "textDocument": {"uri": path_to_uri(path)},
+            "position": {"line": row, "character": col},
+        }, timeout=timeout)
+        if not res:
+            return None
+        return _hover_text(res.get("contents")) or None
+
+    @staticmethod
+    def _loc(loc: dict):
+        uri = loc.get("uri") or loc.get("targetUri", "")
+        rng = loc.get("range") or loc.get("targetSelectionRange") or {}
+        start = rng.get("start") or {}
+        return (uri_to_path(uri), start.get("line", 0) + 1,
+                start.get("character", 0) + 1)
+
+    def pull_diagnostics(self, path: str, timeout: float = 5.0):
+        """textDocument/diagnostic (LSP 3.17 pull model): the server's current
+        diagnostics for `path`, synchronously. Raises on servers that don't
+        implement it (callers then fall back to the push stream)."""
+        res = self.request("textDocument/diagnostic", {
+            "textDocument": {"uri": path_to_uri(path)},
+        }, timeout=timeout)
+        if isinstance(res, dict):
+            return res.get("items") or []
+        return []
+
+    # -- push streams ------------------------------------------------------
+
+    def diag_generation(self, path: str) -> int:
+        with self._cond:
+            return self._diags.get(path_to_uri(path), (0, None))[0]
+
+    def wait_diagnostics(self, path: str, after_generation: int, timeout: float = 5.0):
+        """The first publishDiagnostics for `path` newer than `after_generation`
+        (i.e. the analysis of OUR edit, not a stale set), or None on timeout."""
+        uri = path_to_uri(path)
+        deadline = time.monotonic() + timeout
+        with self._cond:
+            while True:
+                gen, diags = self._diags.get(uri, (0, None))
+                if gen > after_generation:
+                    return diags
+                remaining = deadline - time.monotonic()
+                if remaining <= 0 or not self._cond.wait(remaining):
+                    return None
+
+    def wait_log(self, pattern: str, timeout: float) -> bool:
+        """True once any window/logMessage (past or future) matches `pattern` —
+        how registry readiness rules block until a server stops lying (pyright
+        answers references with a confident [] until its scan logs completion)."""
+        rx = re.compile(pattern)
+        deadline = time.monotonic() + timeout
+        scanned = 0
+        with self._cond:
+            while True:
+                logs = list(self._logs)
+                if any(rx.search(m) for m in logs[scanned:]):
+                    return True
+                scanned = len(logs)
+                remaining = deadline - time.monotonic()
+                if remaining <= 0 or not self._cond.wait(remaining):
+                    return False
+
+
+def _hover_text(contents) -> str:
+    """Hover contents in all three spec shapes, flattened to plain text."""
+    if contents is None:
+        return ""
+    if isinstance(contents, str):
+        return contents.strip()
+    if isinstance(contents, dict):     # MarkupContent | MarkedString {language,value}
+        return str(contents.get("value", "")).strip()
+    if isinstance(contents, list):
+        return "\n".join(filter(None, (_hover_text(c) for c in contents))).strip()
+    return str(contents).strip()

--- a/src/chad/lspservers.py
+++ b/src/chad/lspservers.py
@@ -1,0 +1,157 @@
+"""The language-server registry: which server speaks for which language, as DATA.
+
+Prior art shapes this file: nvim-lspconfig and helix's languages.toml prove that
+once a generic client exists (lspclient.py), each language server is a ~15-line
+declaration — command candidates, an LSP languageId, and quirks. solidlsp reached
+the same conclusion the heavy way: 50 of its 69 adapters were launch-only code.
+
+The availability contract, per row, honest and explicit:
+  * "path"  — the server must already be on PATH (rust-analyzer, gopls, clangd:
+              toolchain-managed binaries chad must not install),
+  * "uvx"   — fetchable via uv's tool runner. `uvx chad-code` PROVES uv is
+              installed, so python precision is guaranteed on the primary install
+              path (network permitting) with zero configuration,
+  * "npx"   — fetchable via npm's runner when node is present.
+Candidates are tried in order; PATH binaries win over fetchers (no network, no
+version surprise). Languages that need a toolchain bootstrap chad refuses to own
+(jdtls: java + a gradle download; omnisharp: a .NET install) get `commands=()` —
+a row that SAYS it's unsupported beats a half-support that hangs.
+
+`decorative_ok` marks servers cheap enough to *start* for a decorative "used by"
+annotation (measured: pyright ~0.9s flat; clangd chewed one file ~10s and a mixed
+repo's disambiguation for 86s). Everyone else only decorates when already running.
+
+`ready_log` is the readiness signal: pyright answers references with a confident
+EMPTY list until initial analysis finishes, and the only reliable tell is its
+`window/logMessage` "Found N source files" (solidlsp's comment: "pyright is
+unreliable and there seems to be no better way"). Rows without a rule are usable
+right after `initialize` returns.
+"""
+
+import os
+import shutil
+from typing import NamedTuple, Optional
+
+# One exact pyright: a fetched server must not drift under chad between sessions.
+_PYRIGHT_PIN = "1.1.403"
+
+
+class ServerSpec(NamedTuple):
+    language: str            # chad's language id (lowercase; ours, not a vendor enum)
+    language_id: str         # LSP languageId sent in didOpen
+    server_key: str          # servers that speak several languages share one process
+    commands: tuple          # candidate argv tuples, first resolvable wins
+    tier: str                # "path" | "uvx" | "npx"  (of the *preferred* fetch row)
+    decorative_ok: bool = False   # cheap enough to SPAWN for a "used by …" hint
+    ready_log: Optional[str] = None   # logMessage regex that marks real readiness
+    ready_timeout_s: float = 60.0
+    # Project files, one of which must exist under the root before the server
+    # starts at all. This is the honesty gate: clangd without a compile database
+    # and TS without a tsconfig both "work" while returning confidently EMPTY
+    # cross-file results (both measured) — worse than the labeled name-match
+    # fallback. Empty tuple = no gate.
+    project_gate: tuple = ()
+    unsupported: str = ""    # human reason when commands is empty
+    settings: Optional[dict] = None   # pushed via workspace/didChangeConfiguration
+                                      # right after initialize; pyright never starts
+                                      # analyzing without one (measured: refs hang)
+
+
+_PYRIGHT = ServerSpec(
+    language="python", language_id="python", server_key="pyright",
+    commands=(("pyright-langserver", "--stdio"),
+              ("uvx", "--from", f"pyright=={_PYRIGHT_PIN}",
+               "pyright-langserver", "--stdio")),
+    tier="uvx", decorative_ok=True,
+    ready_log=r"Found \d+ source files?",
+    settings={"python": {"analysis": {"autoSearchPaths": True,
+                                      "useLibraryCodeForTypes": True,
+                                      "diagnosticMode": "openFilesOnly"}}},
+)
+
+# TypeScript 7 (the native compiler) ships its own LSP inside the `typescript`
+# package (`tsc --lsp --stdio`) — no typescript-language-server wrapper, no
+# workspace-typescript resolution dance (measured: the wrapper refuses to start
+# unless the WORKSPACE has a compatible typescript install; the native LSP just
+# runs). PATH wrapper first for classic setups that have it; native via npx else.
+_TYPESCRIPT = ServerSpec(
+    language="typescript", language_id="typescript", server_key="typescript",
+    commands=(("typescript-language-server", "--stdio"),
+              ("npx", "-y", "-p", "typescript", "tsc", "--lsp", "--stdio")),
+    tier="npx",
+    project_gate=("tsconfig.json", "jsconfig.json"),
+)
+
+_CPP = ServerSpec(
+    language="cpp", language_id="cpp", server_key="clangd",
+    commands=(("clangd", "--background-index"),),
+    tier="path",
+    project_gate=("compile_commands.json",
+                  os.path.join("build", "compile_commands.json"), ".clangd"),
+)
+
+SERVERS = (
+    _PYRIGHT,
+    _TYPESCRIPT,
+    _TYPESCRIPT._replace(language="javascript", language_id="javascript"),
+    ServerSpec(language="go", language_id="go", server_key="gopls",
+               commands=(("gopls", "serve"),), tier="path"),
+    ServerSpec(language="rust", language_id="rust", server_key="rust-analyzer",
+               commands=(("rust-analyzer",),), tier="path"),
+    _CPP._replace(language="c", language_id="c"),
+    _CPP,
+    ServerSpec(language="ruby", language_id="ruby", server_key="solargraph",
+               commands=(("solargraph", "stdio"),), tier="path"),
+    ServerSpec(language="php", language_id="php", server_key="intelephense",
+               commands=(("intelephense", "--stdio"),
+                         ("npx", "-y", "intelephense", "--stdio")),
+               tier="npx"),
+    ServerSpec(language="kotlin", language_id="kotlin", server_key="kotlin",
+               commands=(("kotlin-language-server",),), tier="path"),
+    ServerSpec(language="java", language_id="java", server_key="jdtls",
+               commands=(), tier="path",
+               unsupported="jdtls needs a JDK plus a workspace bootstrap chad "
+                           "does not own; use find_refs (name-match) for java"),
+    ServerSpec(language="csharp", language_id="csharp", server_key="omnisharp",
+               commands=(), tier="path",
+               unsupported="omnisharp/roslyn needs a .NET install chad does not "
+                           "own; use find_refs (name-match) for c#"),
+)
+
+_BY_LANGUAGE = {s.language: s for s in SERVERS}
+
+# Extension -> chad language id. Chad's OWN identity: .js is javascript (served by
+# the typescript server, but named for what it is) and .c/.h are c, not "CPP" —
+# both were vendor-enum spellings inherited from solidlsp.
+LANG_BY_EXT = {
+    ".py": "python", ".pyi": "python",
+    ".ts": "typescript", ".tsx": "typescript",
+    ".js": "javascript", ".jsx": "javascript", ".mjs": "javascript",
+    ".go": "go", ".rs": "rust", ".java": "java", ".rb": "ruby",
+    ".cs": "csharp", ".php": "php", ".kt": "kotlin",
+    ".c": "c", ".h": "c",
+    ".cpp": "cpp", ".cc": "cpp", ".hpp": "cpp",
+}
+
+
+def lang_for(path: str) -> Optional[str]:
+    return LANG_BY_EXT.get(os.path.splitext(path)[1].lower())
+
+
+def spec_for(lang: str) -> Optional[ServerSpec]:
+    return _BY_LANGUAGE.get(lang)
+
+
+def resolve_commands(spec: ServerSpec):
+    """Every candidate whose launcher exists on PATH, best first. A `uvx`/`npx`
+    row resolves when the runner exists — the runner then fetches the server.
+    Callers try them in order: a candidate that resolves but fails to START
+    (e.g. typescript-language-server with no workspace typescript) must not
+    block the next one."""
+    return [list(cand) for cand in spec.commands if shutil.which(cand[0])]
+
+
+def resolve_command(spec: ServerSpec):
+    """The single best candidate, or None (see resolve_commands)."""
+    cands = resolve_commands(spec)
+    return cands[0] if cands else None

--- a/src/chad/mcp.py
+++ b/src/chad/mcp.py
@@ -6,7 +6,7 @@ doesn't ship: a GitHub server, a Postgres server, Linear/Slack/Atlassian, a
 company's internal API, etc. This is the same extension mechanism Claude Code uses.
 
 Transport is provided by the official `mcp` Python SDK (`stdio_client` for local
-subprocess servers, `streamablehttp_client` for hosted HTTP servers). The SDK is
+subprocess servers, `streamable_http_client` for hosted HTTP servers). The SDK is
 **async (anyio)**; chad's tool layer is **synchronous and blocking**. The bridge is
 a single `anyio.from_thread.BlockingPortal` running one event loop in a background
 thread, owned by the registry for its lifetime. Each server's transport +
@@ -56,20 +56,23 @@ from anyio.from_thread import start_blocking_portal
 # this is the backstop, so an incompatible SDK costs the operator their MCP tools and a
 # warning line instead of the agent. `_SDK_ERROR` is checked in `_Registry._connect`.
 #
-# `streamablehttp_client(url, headers=..., auth=...)` is the documented HTTP entry
-# point that takes headers (and an `auth=` OAuth provider) directly, building the httpx
-# client via MCP's own factory with the right defaults. 1.28.1 marks it deprecated in
-# favour of `streamable_http_client(url, *, http_client=...)`, but that variant has no
-# `headers=`/`auth=` — you'd hand-build an httpx client and risk dropping MCP's required
-# client config — so we keep this one until the new API grows an equivalent.
+# mcp 2.x API: `streamable_http_client(url, *, http_client=...)` — the caller builds
+# and owns the httpx2 client. `create_mcp_http_client(headers=..., auth=...)` is MCP's
+# own factory with the required client defaults, so headers and the OAuth provider go
+# there (the 1.x `streamablehttp_client(url, headers=, auth=)` form is gone).
 try:
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.stdio import stdio_client
-    from mcp.client.streamable_http import streamablehttp_client
+    from mcp.client.streamable_http import (
+        create_mcp_http_client,
+        streamable_http_client,
+    )
+    from mcp.types import PaginatedRequestParams
     _SDK_ERROR: Optional[str] = None
 except Exception as _e:  # noqa: BLE001 — any import-time failure, not just ImportError
     ClientSession = StdioServerParameters = None    # type: ignore[assignment,misc]
-    stdio_client = streamablehttp_client = None     # type: ignore[assignment]
+    stdio_client = streamable_http_client = None    # type: ignore[assignment]
+    create_mcp_http_client = PaginatedRequestParams = None  # type: ignore[assignment,misc]
     _SDK_ERROR = f"{type(_e).__name__}: {_e}"
 
 from . import mcp_oauth
@@ -229,18 +232,32 @@ def _stdio_env(environ, extra) -> dict:
     return env
 
 
+def _http_transport(url: str, headers, auth):
+    """The mcp 2.x HTTP transport with the httpx2 client's lifecycle owned HERE:
+    `streamable_http_client` no longer takes headers=/auth= — they go into MCP's
+    own client factory — and no longer closes the client for us."""
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def open_transport():
+        async with create_mcp_http_client(headers=headers, auth=auth) as http_client:
+            async with streamable_http_client(url, http_client=http_client) as streams:
+                yield streams
+    return open_transport()
+
+
 def _transport_for(spec: dict, auth=None):
     """Return (kind, build) for a server spec, where `build()` is a zero-arg factory
     that yields the SDK transport async context manager. Transport is chosen by
     presence: `url` -> HTTP, else `command` -> stdio (`type` is advisory only).
-    `auth` is an optional OAuthClientProvider passed straight through to
-    `streamablehttp_client(..., auth=...)`; None keeps the static bearer/header path.
-    Returns (None, None) if neither is present."""
+    `auth` is an optional OAuthClientProvider handed to the httpx2 client factory;
+    None keeps the static bearer/header path. Returns (None, None) if neither is
+    present."""
     url = spec.get("url")
     if isinstance(url, str) and url:
         headers = spec.get("headers")
         headers = headers if isinstance(headers, dict) else None
-        return "http", lambda: streamablehttp_client(url, headers=headers, auth=auth)
+        return "http", lambda: _http_transport(url, headers, auth)
     command = spec.get("command")
     if isinstance(command, str) and command:
         env = _stdio_env(os.environ, spec.get("env"))
@@ -264,9 +281,10 @@ async def _list_all_tools(session: "ClientSession"):
     out = []
     cursor = None
     for _ in range(_MAX_LIST_PAGES):
-        result = await session.list_tools(cursor) if cursor else await session.list_tools()
+        params = PaginatedRequestParams(cursor=cursor) if cursor else None
+        result = await session.list_tools(params=params)
         out += [t for t in (result.tools or []) if getattr(t, "name", None)]
-        cursor = result.nextCursor
+        cursor = result.next_cursor
         if not cursor:
             break
     return out
@@ -312,7 +330,7 @@ async def _invoke(session: "ClientSession", raw: str, arguments: dict, timeout: 
 
 def _render_result(res) -> str:
     """Flatten an SDK `CallToolResult` into text for the model. Concatenates text
-    content blocks; notes non-text blocks (images/resources) by type. Honors isError
+    content blocks; notes non-text blocks (images/resources) by type. Honors is_error
     by prefixing the text so the model treats it as a failure to react to."""
     parts = []
     for block in (getattr(res, "content", None) or []):
@@ -330,8 +348,8 @@ def _render_result(res) -> str:
         else:
             parts.append(f"[{btype or 'non-text'} content omitted]")
     text = "\n".join(p for p in parts if p)
-    # Some servers return only structuredContent (no content blocks).
-    sc = getattr(res, "structuredContent", None)
+    # Some servers return only structured_content (no content blocks).
+    sc = getattr(res, "structured_content", None)
     if not text and sc is not None:
         try:
             text = json.dumps(sc, ensure_ascii=False, indent=2)
@@ -339,7 +357,10 @@ def _render_result(res) -> str:
             text = str(sc)
     if not text:
         text = "[no content]"
-    if getattr(res, "isError", False):
+    # `is_error` (was isError in mcp 1.x): a getattr on the OLD name would default
+    # False forever and tool-reported errors would silently stop being flagged —
+    # pinned by a test that fails on the 1.x spelling.
+    if getattr(res, "is_error", False):
         text = "[tool reported an error]\n" + text
     return text[:_RESULT_MAX_CHARS]
 
@@ -367,7 +388,7 @@ class _Conn:
 
     def call(self, raw: str, arguments: dict) -> str:
         """Invoke one tool and return its result text. Raises on transport/timeout
-        error; a tool-reported error (isError) is returned as text via _render_result."""
+        error; a tool-reported error (is_error) is returned as text via _render_result."""
         timeout = self.spec.get("timeout")
         timeout = timeout if isinstance(timeout, (int, float)) else _CALL_TIMEOUT
         res = self.portal.call(partial(_invoke, self.session, raw, arguments, timeout))
@@ -508,7 +529,7 @@ class _Registry:
             if full in self.by_tool:  # two servers, same tool name — keep first, warn
                 self.warnings.append(f"{full}: duplicate tool name; later copy ignored")
                 continue
-            schema = t.inputSchema
+            schema = t.input_schema
             if not isinstance(schema, dict) or schema.get("type") != "object":
                 schema = {"type": "object", "properties": {}}
             self.by_tool[full] = (conn, raw)
@@ -569,12 +590,15 @@ def _describe(server: str, tool) -> str:
 
 
 def _is_mutating(tool) -> bool:
-    """Whether a tool needs the confirm gate. MCP `annotations.readOnlyHint == true`
-    means the server promises no side effects -> safe to auto-run; anything else is
-    treated as mutating (the safe default: an MCP tool may write files, hit an API, or
-    send a message, and we'd rather over-confirm than act unprompted)."""
+    """Whether a tool needs the confirm gate. MCP `annotations.read_only_hint == true`
+    (readOnlyHint in mcp 1.x — a getattr on the old name would default None and every
+    read-only tool would silently start demanding confirmation; pinned by a test that
+    fails on the 1.x spelling) means the server promises no side effects -> safe to
+    auto-run; anything else is treated as mutating (the safe default: an MCP tool may
+    write files, hit an API, or send a message, and we'd rather over-confirm than act
+    unprompted)."""
     ann = getattr(tool, "annotations", None)
-    if ann is not None and getattr(ann, "readOnlyHint", None) is True:
+    if ann is not None and getattr(ann, "read_only_hint", None) is True:
         return False
     return True
 
@@ -652,7 +676,7 @@ def login(name: str, emit=None) -> str:
         # initialize() triggers the SDK's OAuth flow (401 -> authorize -> browser ->
         # loopback redirect -> token exchange); tokens are persisted by `storage` along
         # the way. We only need the handshake to complete for that to happen.
-        async with streamablehttp_client(url, headers=headers, auth=provider) as streams:
+        async with _http_transport(url, headers, provider) as streams:
             async with ClientSession(streams[0], streams[1]) as session:
                 with anyio.fail_after(mcp_oauth._LOGIN_TIMEOUT + 30):
                     await session.initialize()

--- a/src/chad/mcp.py
+++ b/src/chad/mcp.py
@@ -47,17 +47,30 @@ from typing import Any, Optional
 
 import anyio
 from anyio.from_thread import start_blocking_portal
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
 
+# The SDK import is GUARDED. Everything else in this module degrades when a server is
+# missing or broken; the one thing that used to take the whole process down was the SDK
+# itself changing shape underneath us — chad.mcp is imported unconditionally by Agent's
+# constructor, so an ImportError here is a traceback on `chad` with no way past it. (It
+# happened: mcp 2.0 removed `streamablehttp_client`.) The dep is capped in pyproject;
+# this is the backstop, so an incompatible SDK costs the operator their MCP tools and a
+# warning line instead of the agent. `_SDK_ERROR` is checked in `_Registry._connect`.
+#
 # `streamablehttp_client(url, headers=..., auth=...)` is the documented HTTP entry
-# point that takes headers (and, in , an `auth=` OAuth provider) directly,
-# building the httpx client via MCP's own factory with the right defaults. mcp 1.28.1
-# marks it deprecated in favour of `streamable_http_client(url, *, http_client=...)`,
-# but that variant has no `headers=`/`auth=` — you'd hand-build an httpx client and
-# risk dropping MCP's required client config — so we keep this one until the new API
-# grows an equivalent. (Confirmed against mcp==1.28.1.)
-from mcp.client.streamable_http import streamablehttp_client
+# point that takes headers (and an `auth=` OAuth provider) directly, building the httpx
+# client via MCP's own factory with the right defaults. 1.28.1 marks it deprecated in
+# favour of `streamable_http_client(url, *, http_client=...)`, but that variant has no
+# `headers=`/`auth=` — you'd hand-build an httpx client and risk dropping MCP's required
+# client config — so we keep this one until the new API grows an equivalent.
+try:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+    from mcp.client.streamable_http import streamablehttp_client
+    _SDK_ERROR: Optional[str] = None
+except Exception as _e:  # noqa: BLE001 — any import-time failure, not just ImportError
+    ClientSession = StdioServerParameters = None    # type: ignore[assignment,misc]
+    stdio_client = streamablehttp_client = None     # type: ignore[assignment]
+    _SDK_ERROR = f"{type(_e).__name__}: {_e}"
 
 from . import mcp_oauth
 from .diag import log, warn_footer
@@ -397,6 +410,16 @@ class _Registry:
     def _connect(self):
         servers, warnings = _load_config(self.cwd)
         self.warnings = list(warnings)
+        if _SDK_ERROR:
+            # Unusable SDK: connect nothing, expose no tools, say so once in /mcp and the
+            # warning footer. Configured servers are still read so the message only fires
+            # for operators who actually have some.
+            if servers:
+                self.warnings.append(
+                    f"MCP disabled — the installed `mcp` SDK is not compatible with this "
+                    f"chad ({_SDK_ERROR}). Reinstall chad, or pin `mcp<2`.")
+                log.warning("mcp: SDK unusable, no servers connected: %s", _SDK_ERROR)
+            return
         trusted = _is_trusted(self.cwd)
 
         # Decide which servers we'll actually connect (after disabled/name/trust gates).
@@ -686,7 +709,10 @@ def summary_lines():
     """Human-readable rows for the `/mcp` command: one line per server (transport +
     tool count, or its connection error), each server's tools, then any warnings."""
     reg = service()
-    if not reg.clients and not reg.blocked and not reg.needs_login:
+    # `and not reg.warnings`: a config that produced warnings but no connections (malformed
+    # file, unusable SDK, server with neither url nor command) is NOT "no servers
+    # configured" — that early-out would swallow the one message explaining why.
+    if not reg.clients and not reg.blocked and not reg.needs_login and not reg.warnings:
         return ["no MCP servers configured. Add one to .mcp.json (project) or "
                 "~/.chad/mcp.json (user): "
                 '{"mcpServers": {"name": {"command": "...", "args": [...]}}} '

--- a/src/chad/mcp_oauth.py
+++ b/src/chad/mcp_oauth.py
@@ -53,12 +53,25 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs, urlparse
 
 import anyio
-from mcp.client.auth import OAuthClientProvider
-from mcp.shared.auth import (
-    OAuthClientInformationFull,
-    OAuthClientMetadata,
-    OAuthToken,
-)
+
+# Guarded like the transport import in mcp.py, and for the same reason: this module is
+# imported at `chad.mcp` import time, which happens on every Agent construction, so an
+# SDK that moved these symbols would be a traceback on startup rather than a degraded
+# feature. With the SDK unusable `oauth_enabled()` reports False and no OAuth code path
+# is ever entered — the same shape as the operator leaving the flag off.
+try:
+    from mcp.client.auth import OAuthClientProvider
+    from mcp.shared.auth import (
+        OAuthClientInformationFull,
+        OAuthClientMetadata,
+        OAuthToken,
+    )
+    _SDK_ERROR: "str | None" = None
+except Exception as _e:  # noqa: BLE001 — any import-time failure, not just ImportError
+    OAuthClientProvider = None                                   # type: ignore[assignment,misc]
+    OAuthClientInformationFull = OAuthClientMetadata = None       # type: ignore[assignment,misc]
+    OAuthToken = None                                             # type: ignore[assignment,misc]
+    _SDK_ERROR = f"{type(_e).__name__}: {_e}"
 
 from .diag import log
 
@@ -76,7 +89,12 @@ _POLL = 1.0
 
 def oauth_enabled() -> bool:
     """True only when the operator has opted into OAuth via `CHAD_MCP_OAUTH`. With this
-    off, no OAuth code runs and the stdio/bearer/HTTP paths are unaffected."""
+    off, no OAuth code runs and the stdio/bearer/HTTP paths are unaffected. An SDK whose
+    auth symbols we couldn't import reads as off, so the callers' existing "OAuth
+    unavailable" path handles it — nothing here can raise."""
+    if _SDK_ERROR:
+        log.warning("mcp: OAuth unavailable, SDK auth import failed: %s", _SDK_ERROR)
+        return False
     val = os.environ.get("CHAD_MCP_OAUTH", "")
     return val.strip().lower() not in ("", "0", "false", "no", "off")
 

--- a/src/chad/mcp_oauth.py
+++ b/src/chad/mcp_oauth.py
@@ -18,11 +18,13 @@ Everything here is gated by the `CHAD_MCP_OAUTH` feature flag (see `oauth_enable
 With the flag off, an `auth: oauth` server is skipped with a warning and the
 stdio/bearer/HTTP paths are unchanged — none of this code runs.
 
-SDK API confirmed against **mcp==1.28.1** (`mcp.__version__` does not exist; use
+SDK API confirmed against **mcp==2.0.0** (`mcp.__version__` does not exist; use
 `importlib.metadata.version("mcp")`):
   - `from mcp.client.auth import OAuthClientProvider, TokenStorage`
   - `OAuthClientProvider(server_url, client_metadata, storage, redirect_handler,
-     callback_handler, timeout=300.0, client_metadata_url=None)`
+     callback_handler, client_metadata_url=None, validate_resource_url=None)`
+  - `callback_handler` returns `AuthorizationCodeResult` (mcp.shared.auth; fields
+    code/state/iss) — the 1.x `(code, state)` tuple form is gone.
   - `TokenStorage` is a 4-method **async** protocol:
         get_tokens()       -> OAuthToken | None
         set_tokens(tokens) -> None
@@ -30,13 +32,12 @@ SDK API confirmed against **mcp==1.28.1** (`mcp.__version__` does not exist; use
         set_client_info(client_info) -> None
   - models live in `mcp.shared.auth`: `OAuthClientMetadata` (only `redirect_uris`
     is required), `OAuthToken` (`access_token` required), `OAuthClientInformationFull`.
-  - `OAuthClientProvider` is an `httpx.Auth`; Dynamic Client Registration is performed
+  - `OAuthClientProvider` is an `httpx2.Auth`; Dynamic Client Registration is performed
     internally during its auth flow when the server advertises a registration endpoint
     and no client_info is stored (so we never hand-roll DCR).
-  - `streamablehttp_client(url, headers=..., auth=<provider>)` accepts the provider —
-    this is exactly why chad keeps the deprecated `streamablehttp_client` (the
-    newer `streamable_http_client` has no `auth=`).
-No divergence from the assumed API was found.
+  - the provider goes into `create_mcp_http_client(headers=..., auth=<provider>)`,
+    whose client feeds `streamable_http_client(url, http_client=...)` (see mcp.py).
+No further divergence from the assumed API was found.
 
 NOTE / e2e gap: a full 3-legged OAuth handshake against a real authorization server is
 NOT exercised in tests (there is no real IdP in CI). The seams are tested — token-store
@@ -62,13 +63,14 @@ import anyio
 try:
     from mcp.client.auth import OAuthClientProvider
     from mcp.shared.auth import (
+        AuthorizationCodeResult,
         OAuthClientInformationFull,
         OAuthClientMetadata,
         OAuthToken,
     )
     _SDK_ERROR: "str | None" = None
 except Exception as _e:  # noqa: BLE001 — any import-time failure, not just ImportError
-    OAuthClientProvider = None                                   # type: ignore[assignment,misc]
+    OAuthClientProvider = AuthorizationCodeResult = None          # type: ignore[assignment,misc]
     OAuthClientInformationFull = OAuthClientMetadata = None       # type: ignore[assignment,misc]
     OAuthToken = None                                             # type: ignore[assignment,misc]
     _SDK_ERROR = f"{type(_e).__name__}: {_e}"
@@ -329,14 +331,15 @@ def make_login_provider(server_url: str, storage: "FileTokenStorage",
             say("No browser available. Open this URL to approve access:")
         say(auth_url)
 
-    async def callback_handler() -> "tuple[str, str | None]":
+    async def callback_handler() -> "AuthorizationCodeResult":
         res = await anyio.to_thread.run_sync(loopback.wait, timeout)
         if res is None:
             raise TimeoutError(f"OAuth login timed out after {int(timeout)}s")
         code, state = res
         if not code:
             raise RuntimeError("OAuth login did not return an authorization code")
-        return code, state
+        # mcp 2.x: a typed result, not the 1.x (code, state) tuple
+        return AuthorizationCodeResult(code=code, state=state)
 
     return OAuthClientProvider(
         server_url=server_url,

--- a/src/chad/repomap.py
+++ b/src/chad/repomap.py
@@ -86,7 +86,7 @@ _MAX_DEFINERS = 16
 #      re-import chad's entry point, which would drag the whole MLX engine into each.
 _PARALLEL_MIN_FILES = 200   # below this, worker startup costs more than it saves
 _CACHE_SAVE_MIN = 32        # don't persist a cache for tiny repos (or tiny test fixtures)
-_CACHE_VERSION = 2          # bump when the entry shape or tags queries change
+_CACHE_VERSION = 3          # bump when the entry shape or tags queries change
 _CACHE_DIR = os.path.expanduser("~/.chad/cache/repomap")
 
 _WORKER_SRC = """\
@@ -145,6 +145,18 @@ _TS_TAGS = """\
 _TAGS_OVERRIDE = {
     "typescript": _TS_TAGS,
     "tsx": _TS_TAGS,
+    # The pack ships NO bash tags query, yet shell is everywhere real.  Without
+    # tags, every .sh function is invisible to repo_map/overview/view_symbol and the
+    # symbol editor. Functions (both `f() {}` and `function f {}` parse to the same
+    # node), TOP-LEVEL variable assignments only (anchored to program: config
+    # constants surface, function-local temps don't), and command invocations as
+    # references (builtins like echo/set resolve to no definer, so the rank graph
+    # ignores them; invocations of repo-defined functions are exactly find_refs).
+    "bash": """\
+(function_definition name: (word) @name) @definition.function
+(program (variable_assignment name: (variable_name) @name) @definition.constant)
+(command name: (command_name (word) @name)) @reference.call
+""",
     "go": """\
 (function_declaration name: (identifier) @name) @definition.function
 (method_declaration

--- a/src/chad/repomap.py
+++ b/src/chad/repomap.py
@@ -12,16 +12,17 @@ This is the aider "repo map" idea, built in-process on tree-sitter:
 * `tree-sitter-language-pack` ships ~300 grammars (downloaded + cached on first use)
   AND the `tags.scm` queries that mark every definition/reference — so symbol
   extraction is **language-agnostic** with no language-server subprocess to install
-  (that precision layer comes later, behind this same surface, via solidlsp).
+  (the precision layer sits behind this same surface, via chad's own LSP client).
 * `repo_map()` ranks definitions with personalized PageRank (rustworkx) over the
   file→symbol reference graph and renders the most central ones as elided signatures
   within a token budget. Whole-repo tag extraction is mtime-cached on disk per repo
   and sharded across subprocess workers on a cold scan (see `_extract_all`).
 * `overview` / `find_symbol` / `view_symbol` / `find_refs` are the per-symbol read
-  tools, now multi-language (they replace the Python-only jedi backend in
-  `symbols.py`; jedi remains the editor for `replace_symbol`/`insert_symbol`).
-
-API mirrors `symbols.SymbolService` so `tools.py` can route to either backend.
+  tools, multi-language. Qualified paths ("Engine/generate") resolve in every
+  language via each Tag's scope chain — span containment plus receiver/impl
+  context (see `Tag`). `symbols.py` (the `replace_symbol`/`insert_symbol` editor)
+  resolves through the same `_find_defs`, so what the model views is what an edit
+  replaces, in any language.
 """
 
 import hashlib
@@ -85,7 +86,7 @@ _MAX_DEFINERS = 16
 #      re-import chad's entry point, which would drag the whole MLX engine into each.
 _PARALLEL_MIN_FILES = 200   # below this, worker startup costs more than it saves
 _CACHE_SAVE_MIN = 32        # don't persist a cache for tiny repos (or tiny test fixtures)
-_CACHE_VERSION = 1          # bump when the entry shape or tags queries change
+_CACHE_VERSION = 2          # bump when the entry shape or tags queries change
 _CACHE_DIR = os.path.expanduser("~/.chad/cache/repomap")
 
 _WORKER_SRC = """\
@@ -105,11 +106,153 @@ def _worker_count() -> int:
         return n
     return max(1, min(8, (os.cpu_count() or 4) - 2))
 
+
+# Chad-owned tags queries for languages where the pack's are missing or broken
+# (measured on tests/fixtures/polyglot, 2026-07-29): typescript/tsx ship NO query
+# (0 chars); php's names `method_call_expression`, which current tree-sitter-php
+# renamed `member_call_expression`, so Query() refuses to compile the whole thing;
+# c has no @reference captures and tags header prototypes as definitions; cpp
+# misses out-of-class (`Engine::process`) and in-class method definitions.
+_TS_TAGS = """\
+(class_declaration name: (type_identifier) @name) @definition.class
+(abstract_class_declaration name: (type_identifier) @name) @definition.class
+(interface_declaration name: (type_identifier) @name) @definition.interface
+(type_alias_declaration name: (type_identifier) @name) @definition.type
+(enum_declaration name: (identifier) @name) @definition.type
+(internal_module name: (identifier) @name) @definition.module
+(function_declaration name: (identifier) @name) @definition.function
+(generator_function_declaration name: (identifier) @name) @definition.function
+((method_definition name: (property_identifier) @name) @definition.method
+ (#not-eq? @name "constructor"))
+(method_signature name: (property_identifier) @name) @definition.method
+(lexical_declaration (variable_declarator
+  name: (identifier) @name
+  value: [(arrow_function) (function_expression)]) @definition.function)
+(variable_declaration (variable_declarator
+  name: (identifier) @name
+  value: [(arrow_function) (function_expression)]) @definition.function)
+((call_expression function: (identifier) @name) @reference.call
+ (#not-match? @name "^(require)$"))
+(call_expression function: (member_expression
+  property: (property_identifier) @name)) @reference.call
+(new_expression constructor: (identifier) @name) @reference.class
+"""
+
+# go and rust attach methods without lexical nesting (receivers / impl blocks), so
+# span containment alone can't derive `Engine/Process` there. Their overrides add
+# @context.receiver (the method's receiver type) and @context.scope (the impl
+# block's span) on top of the pack's own captures.
+_TAGS_OVERRIDE = {
+    "typescript": _TS_TAGS,
+    "tsx": _TS_TAGS,
+    "go": """\
+(function_declaration name: (identifier) @name) @definition.function
+(method_declaration
+  receiver: (parameter_list (parameter_declaration
+    type: [(type_identifier) @context.receiver
+           (pointer_type (type_identifier) @context.receiver)]))
+  name: (field_identifier) @name) @definition.method
+(type_spec name: (type_identifier) @name) @definition.type
+(call_expression function: [
+  (identifier) @name
+  (parenthesized_expression (identifier) @name)
+  (selector_expression field: (field_identifier) @name)
+  (parenthesized_expression (selector_expression field: (field_identifier) @name))
+]) @reference.call
+(type_identifier) @name @reference.type
+""",
+    "rust": """\
+(struct_item name: (type_identifier) @name) @definition.class
+(enum_item name: (type_identifier) @name) @definition.class
+(union_item name: (type_identifier) @name) @definition.class
+(type_item name: (type_identifier) @name) @definition.class
+(declaration_list (function_item name: (identifier) @name) @definition.method)
+(function_item name: (identifier) @name) @definition.function
+(trait_item name: (type_identifier) @name) @definition.interface
+(mod_item name: (identifier) @name) @definition.module
+(macro_definition name: (identifier) @name) @definition.macro
+(call_expression function: (identifier) @name) @reference.call
+(call_expression function: (field_expression
+  field: (field_identifier) @name)) @reference.call
+(macro_invocation macro: (identifier) @name) @reference.call
+(impl_item trait: (type_identifier) @name) @reference.implementation
+(impl_item type: (type_identifier) @name !trait) @reference.implementation
+(impl_item type: (type_identifier) @name) @context.scope
+(impl_item type: (generic_type type: (type_identifier) @name)) @context.scope
+""",
+    "php": """\
+(class_declaration name: (name) @name) @definition.class
+(interface_declaration name: (name) @name) @definition.interface
+(method_declaration name: (name) @name) @definition.method
+(function_definition name: (name) @name) @definition.function
+(class_declaration (base_clause (name) @name)) @reference.implementation
+(class_declaration (class_interface_clause (name) @name)) @reference.implementation
+(interface_declaration (base_clause (name) @name)) @reference.implementation
+(function_call_expression function: (name) @name) @reference.call
+(member_call_expression name: (name) @name) @reference.call
+(scoped_call_expression name: (name) @name) @reference.call
+""",
+    "c": """\
+(function_definition declarator: (function_declarator
+  declarator: (identifier) @name)) @definition.function
+(function_definition declarator: (pointer_declarator
+  declarator: (function_declarator
+    declarator: (identifier) @name))) @definition.function
+(struct_specifier name: (type_identifier) @name body: (_)) @definition.class
+(declaration type: (union_specifier name: (type_identifier) @name)) @definition.class
+(type_definition declarator: (type_identifier) @name) @definition.type
+(enum_specifier name: (type_identifier) @name) @definition.type
+(call_expression function: (identifier) @name) @reference.call
+""",
+    "cpp": """\
+(class_specifier name: (type_identifier) @name) @definition.class
+(struct_specifier name: (type_identifier) @name body: (_)) @definition.class
+(function_definition declarator: (function_declarator
+  declarator: (identifier) @name)) @definition.function
+(function_definition declarator: (function_declarator
+  declarator: (qualified_identifier scope: (_) @context.receiver
+               name: (identifier) @name))) @definition.method
+(function_definition declarator: (function_declarator
+  declarator: (field_identifier) @name)) @definition.method
+(class_specifier (base_class_clause (type_identifier) @name)) @reference.implementation
+(call_expression function: (identifier) @name) @reference.call
+(call_expression function: (field_expression
+  field: (field_identifier) @name)) @reference.call
+""",
+}
+
 # A definition discovered by tree-sitter. `kind` is the tag suffix (function,
 # class, method, constant, ...); `sig` is the collapsed header line(s). `name_row`
 # and `name_col` are the 0-based position of the identifier itself (what an LSP
-# wants for go-to-def / find-references).
-Tag = namedtuple("Tag", "rel path name kind line end_line sig name_row name_col")
+# wants for go-to-def / find-references). `scope` is the enclosing-symbol chain,
+# outermost first (("Engine",) for a method, ("Outer", "Inner") when nested) — how
+# a qualified path like `Engine/generate` resolves in any language: by span
+# containment where methods nest lexically, and by receiver/impl context captures
+# (@context.receiver / @context.scope) where they don't (Go, Rust, C++ Engine::).
+Tag = namedtuple("Tag", "rel path name kind line end_line sig name_row name_col scope")
+
+
+def _scope_chains(spans):
+    """Enclosing-name chains by span containment: spans is [(start, end, name)],
+    returns for each input its chain of strictly-containing names, outermost first.
+    Tree-sitter spans nest or are disjoint (never partially overlap), so a single
+    (start, -end)-ordered pass with a stack is exact and O(n log n)."""
+    order = sorted(range(len(spans)), key=lambda i: (spans[i][0], -spans[i][1]))
+    stack = []  # indices of open (containing) spans
+    chains = [()] * len(spans)
+    for i in order:
+        start, end, _name = spans[i]
+        while stack and spans[stack[-1]][1] < start:
+            stack.pop()
+        chains[i] = tuple(spans[j][2] for j in stack
+                          if (spans[j][0], spans[j][1]) != (start, end))
+        stack.append(i)
+    return chains
+
+
+def _qual_parts(name: str):
+    """A symbol path ("Engine/generate" or "Engine.generate") as its segments."""
+    return [p for p in name.replace(".", "/").split("/") if p]
 
 
 def _estimate_tokens(text: str) -> int:
@@ -157,6 +300,7 @@ class RepoMap:
         self._tooling = {}   # lang -> (Parser, Query) | None
         self._cache = {}     # path -> (mtime, [defs], [(refname, rel, line)])
         self._files = None   # memoized completed _code_files() result; None = uncomputed
+        self._files_at = 0.0  # when that walk completed (staleness retry guard)
         self._disk_checked = False  # the on-disk tags cache is loaded at most once
         self._agg = None     # incremental rank-graph tables; see _aggregates()
         self._refsum_cache = {}  # (path, row, col, mtime) -> disambig note
@@ -296,7 +440,7 @@ class RepoMap:
         if lang not in self._tooling:
             try:
                 language = tlp.get_language(lang)
-                qsrc = tlp.get_tags_query(lang)
+                qsrc = _TAGS_OVERRIDE.get(lang) or tlp.get_tags_query(lang)
                 if not qsrc:
                     self._tooling[lang] = None
                 else:
@@ -343,6 +487,7 @@ class RepoMap:
         result = sorted(out)[:_MAX_FILES]
         if not interrupted:        # never cache a partial scan
             self._files = result
+            self._files_at = time.monotonic()
         return result
 
     @staticmethod
@@ -387,22 +532,47 @@ class RepoMap:
                 matches = []
                 src = b""
             rel = self._rel(path)
+            seen_spans = set()  # rust tags an impl fn as method AND function: one Tag
+            raw = []      # (name, kind, line0, end0, sig, nrow, ncol, receiver)
+            scopes = []   # (line0, end0, name) container spans that aren't symbols
+                          # themselves (rust `impl Engine { … }` blocks)
             for _pat, caps in matches:
                 name_nodes = caps.get("name")
                 name = (src[name_nodes[0].start_byte:name_nodes[0].end_byte]
                         .decode("utf-8", "replace")) if name_nodes else None
                 nrow = name_nodes[0].start_point[0] if name_nodes else 0
                 ncol = name_nodes[0].start_point[1] if name_nodes else 0
+                rnodes = caps.get("context.receiver")
+                receiver = (src[rnodes[0].start_byte:rnodes[0].end_byte]
+                            .decode("utf-8", "replace")) if rnodes else None
                 for cap, nodes in caps.items():
                     if cap.startswith("definition") and name:
                         kind = cap.split(".", 1)[1] if "." in cap else "def"
                         for dn in nodes:
-                            defs.append(Tag(rel, path, name, kind,
-                                            dn.start_point[0] + 1, dn.end_point[0] + 1,
-                                            self._header(src, dn), nrow, ncol))
+                            span = (name, dn.start_point[0], dn.end_point[0])
+                            if span in seen_spans:
+                                continue
+                            seen_spans.add(span)
+                            raw.append((name, kind, dn.start_point[0], dn.end_point[0],
+                                        self._header(src, dn), nrow, ncol, receiver))
                     elif cap.startswith("reference") and name:
                         for rn in nodes:
                             refs.append((name, rel, rn.start_point[0] + 1))
+                    elif cap.startswith("context.scope") and name:
+                        for sn in nodes:
+                            scopes.append((sn.start_point[0], sn.end_point[0], name))
+            # Scope chains: lexical containment over this file's defs + context
+            # spans, then the receiver (Go `func (e Engine)`, C++ `Engine::`)
+            # appended where the language attaches methods without nesting them.
+            spans = [(r[2], r[3], r[0]) for r in raw] + scopes
+            chains = _scope_chains(spans)
+            for i, (name, kind, l0, e0, sig, nrow, ncol, receiver) in enumerate(raw):
+                scope = chains[i]
+                if receiver:
+                    scope = scope + tuple(_qual_parts(
+                        receiver.replace("::", "/").lstrip("*").strip()))
+                defs.append(Tag(rel, path, name, kind, l0 + 1, e0 + 1,
+                                sig, nrow, ncol, scope))
         self._cache[path] = (mtime, defs, refs)
         return defs, refs
 
@@ -522,7 +692,15 @@ class RepoMap:
     # -- per-symbol reads (multi-language) -------------------------------
 
     def _find_defs(self, name, path=None, should_stop=None):
-        target = name.replace(".", "/").split("/")[-1]
+        """Definition Tags matching `name` — a bare identifier or a qualified path
+        ("Engine/generate", "Engine.generate"), any language. Qualified segments
+        must be a suffix of the Tag's scope chain, so `Engine/generate` never
+        silently resolves to a free `generate` (strict, like the jedi backend it
+        replaced); bare names behave exactly as before."""
+        parts = _qual_parts(name)
+        if not parts:
+            return []
+        target, quals = parts[-1], tuple(parts[:-1])
         files = [os.path.join(self.root, path)] if path and not os.path.isabs(path) \
             else ([path] if path else self._code_files(should_stop))
         if not path:
@@ -533,9 +711,27 @@ class RepoMap:
                 break
             defs, _ = self._extract(f)
             for d in defs:
-                if d.name == target:
+                if d.name == target and (
+                        not quals or d.scope[max(0, len(d.scope) - len(quals)):] == quals):
                     hits.append(d)
+        if not hits and path is None and not (should_stop and should_stop()):
+            # The symbol may live in a file created after the memoized walk. Before
+            # reporting not-found, re-walk once — only genuine misses pay this.
+            fresh = self._refresh_files()
+            if fresh:
+                return self._find_defs(name, path, should_stop)
         return hits
+
+    def _refresh_files(self):
+        """Invalidate the memoized file walk if it could be stale; True if a
+        re-walk actually found a different file set (callers then retry their
+        lookup). A walk under a second old is trusted — a burst of misses must
+        not re-walk an 11k-file tree per call."""
+        if self._files is None or time.monotonic() - self._files_at < 1.0:
+            return False
+        before = self._files
+        self._files = None
+        return self._code_files() != before
 
     def _refsum_key(self, h):
         return (h.path, h.name_row, h.name_col, self._cache.get(h.path, (None,))[0])
@@ -636,6 +832,24 @@ class RepoMap:
                          for i in range(a, b + 1) if 0 < i <= len(lines))
         return f"{h.rel}:{a}-{b}\n{body}"
 
+    def hover(self, name: str, path=None, should_stop=None) -> str:
+        """Type signature / resolved type / docs for ONE symbol, via the language
+        server — the model reads a type in ~30 tokens instead of opening the
+        defining file. Name may be qualified ('Engine/process'); degrades to a
+        pointer at view_symbol when no server is available for the language."""
+        hits = self._find_defs(name, path, should_stop)
+        if not hits:
+            return f"[symbol not found: {name}]"
+        if len(hits) > 1 and path is None:
+            return self._disambig(name, hits)
+        h = hits[0]
+        from . import lsp
+        txt = lsp.service().hover(h.rel, h.name_row, h.name_col)
+        if not txt:
+            return ("[no hover info — no language server available for this file "
+                    "type; use view_symbol]")
+        return f"{h.rel}:{h.line}\n{txt[:1200]}"
+
     def find_refs(self, name: str, path=None, should_stop=None) -> str:
         """Every USE of a symbol across the project. Precise when a language server
         is available (follows imports, respects scope, won't confuse same-named
@@ -645,7 +859,7 @@ class RepoMap:
         hits = self._find_defs(name, path, should_stop)
         if hits and not (len(hits) > 1 and path is None):
             h = hits[0]
-            from . import lsp  # lazy: only pay the solidlsp import when refs are requested
+            from . import lsp  # lazy: only start weighing servers when refs are requested
             locs = lsp.service().references(h.rel, h.name_row, h.name_col)
             if locs is not None:
                 if not locs:
@@ -715,7 +929,7 @@ class RepoMap:
                     f"one before renaming:]\n{self._disambig(name, hits)}")
         h = hits[0]
         target = h.name
-        from . import lsp  # lazy: only pay the solidlsp import when a rename is requested
+        from . import lsp  # lazy: only pay the client import when a rename is requested
         locs = lsp.service().references(h.rel, h.name_row, h.name_col)
         if locs is None:
             return ("[rename needs the precise language server (find-all-references), which "

--- a/src/chad/symbols.py
+++ b/src/chad/symbols.py
@@ -1,212 +1,54 @@
 """Symbol EDITOR for chad — `replace_symbol` / `insert_symbol`, all languages.
 
 This module edits code by symbol rather than by text: locate a function / class /
-method by name and replace or insert around it, returning a unified diff. Two
-backends share one splice engine (`_apply` + syntaxgate):
+method by name and replace or insert around it, returning a unified diff. ONE
+backend for every language: the tree-sitter repo map's definition tags
+(`repomap._find_defs`), whose `line`/`end_line` spans are the same ones
+`view_symbol` displays — so what the model just viewed is exactly what an edit
+replaces. The splice engine (`_apply` + syntaxgate) reverts any edit that takes a
+parsing file to a syntax error.
 
-* **Python** goes through jedi (already a dependency, in-process, scope-aware,
-  understands qualified `Class/method` paths).
-* **Every other language** goes through the tree-sitter repo map's definition tags
-  (`repomap._find_defs`), whose `line`/`end_line` spans are the same ones
-  `view_symbol` displays — so what the model just viewed is exactly what an edit
-  replaces. No language-server subprocess on either path.
-
-Symbolic **reads / search / rename** (`overview`, `view_symbol`, `find_symbol`,
-`find_refs`, `repo_map`, `rename_symbol`) live in `repomap.py`, the tree-sitter
-backend — it's language-agnostic and adds LSP "used by" annotations. `tools.py`
-routes reads there and only edits here. A jedi read backend used to live in this
-module too; it was dead (nothing routed to it) and has been removed.
+A jedi backend used to own the Python half of this split (scope-aware, qualified
+paths — Python-only). Qualified paths now resolve for every language via the
+Tags' scope chains (span containment + receiver/impl context; see repomap.Tag),
+so the split — and the jedi dependency — is gone.
 
 Name paths: a bare name ("generate") or a qualified path ("Engine/generate" or
-"Engine.generate") to disambiguate a method from a free function of the same name
-(qualified paths are jedi-only; for other languages pass path=).
+"Engine.generate") to disambiguate a method from a free function of the same
+name, in any language the repo map parses. A name defined in several files
+returns a disambiguation listing; pass path= to pick one.
+
+Symbolic **reads / search / rename** (`overview`, `view_symbol`, `find_symbol`,
+`find_refs`, `repo_map`, `rename_symbol`) live in `repomap.py`; `tools.py`
+routes reads there and only edits here.
 """
 
 import difflib
 import os
-import re
-import time
-from concurrent.futures import ThreadPoolExecutor
-
-import jedi
 
 from . import syntaxgate
-from .ignore import IGNORE_DIRS
 
-# How long a walked .py file list stays fresh. Agent edits come in bursts (locate,
-# replace, re-replace after a failed test); re-walking an 11k-file tree for each one
-# measured ~200ms of pure repetition. 30s is short enough that a file created by a
-# `write`/`bash` step is visible by the time the model turns back to symbol edits.
-_PY_FILES_TTL_S = 30.0
-_NAMES_CACHE_MAX = 16   # (path, mtime)-keyed jedi parses; re-edits of one file are common
-_MAX_DEF_FILES = 16     # more definers than this -> disambiguate by file, skip jedi
 _DISAMBIG_MAX_LINES = 20  # cap disambiguation listings (205 lines of 'main' is prefill)
 
 
-def _norm_path(parts):
-    return [p for p in parts.replace(".", "/").split("/") if p]
-
-
 class SymbolService:
-    """Symbol editor rooted at a project directory: jedi for Python, tree-sitter
-    definition spans for every other language the repo map parses."""
+    """Symbol editor rooted at a project directory: tree-sitter definition spans,
+    every language the repo map parses, qualified paths included."""
 
     def __init__(self, root: str = "."):
         self.root = os.path.abspath(root)
-        self._project = jedi.Project(self.root)
-        self._py_files_cache: list = []
-        self._py_files_at = 0.0
-        self._names_cache: dict = {}  # path -> (mtime, names, code)
-        self._rm = None               # private RepoMap, only if roots diverge (tests)
+        self._rm = None   # private RepoMap, only if roots diverge (tests)
 
-    # -- helpers ----------------------------------------------------------
-
-    def _py_files(self):
-        now = time.monotonic()
-        if self._py_files_cache and now - self._py_files_at < _PY_FILES_TTL_S:
-            return self._py_files_cache
-        out = []
-        for dirpath, dirnames, filenames in os.walk(self.root):
-            # prune ignored + hidden dirs during the walk (never descend into a
-            # node_modules/ or .venv/ at all) instead of filtering the full list after
-            dirnames[:] = [d for d in dirnames
-                           if not d.startswith(".") and d not in IGNORE_DIRS]
-            out.extend(os.path.join(dirpath, fn) for fn in filenames
-                       if fn.endswith(".py") and not fn.startswith("."))
-        self._py_files_cache = sorted(out)[:20000]
-        self._py_files_at = now
-        return self._py_files_cache
-
-    def _candidate_files(self, needle, path=None, should_stop=None):
-        """Files that could DEFINE `needle` — a cheap prefilter so we only run
-        (expensive) jedi analysis on the handful of files that could possibly match,
-        instead of every .py in the project. A hit must put the name on a def/class
-        line (`_is_def`'s contract), so the probe is that textual shape, not a bare
-        substring — `"main" in text` matched thousands of files ("domain", comments,
-        `__main__` guards) and each false candidate cost a full jedi parse: measured
-        130s for _find_defs("main") on an 11k-file repo. Reads are farmed to a thread
-        pool (I/O releases the GIL); order stays deterministic."""
-        probe = re.compile(rf"\b(?:def|class)\s+{re.escape(needle)}\b")
-        files = [path] if path else self._py_files()
-        files = [fp for fp in files if os.path.isfile(fp) and fp.endswith(".py")]
-
-        def scan(chunk):
-            hits = []
-            for fp in chunk:
-                if should_stop and should_stop():
-                    break
-                try:
-                    with open(fp, errors="ignore") as f:
-                        text = f.read()
-                    # substring first: C-speed rejection of the ~all files that don't
-                    # even contain the name; only those pay the regex probe
-                    if needle in text and probe.search(text):
-                        hits.append(fp)
-                except OSError:
-                    continue
-            return hits
-
-        # 8 contiguous chunks, one future each: per-file futures measured ~140ms of
-        # pure executor overhead on 4.5k files. Concatenating in order keeps the
-        # deterministic sorted result.
-        step = max(1, -(-len(files) // 8))
-        chunks = [files[i:i + step] for i in range(0, len(files), step)]
-        out = []
-        with ThreadPoolExecutor(max_workers=8) as pool:
-            for hits in pool.map(scan, chunks):
-                out.extend(hits)
-        return out
-
-    def _script(self, path):
-        with open(path, errors="replace") as f:
-            code = f.read()
-        return jedi.Script(code=code, path=path, project=self._project), code
-
-    @staticmethod
-    def _is_def(code_lines, name_obj):
-        """True only for functions/classes DEFINED in this file. Keyed off the name's
-        own line (cheap, in-file) — NOT get_definition_start_position(), which resolves
-        imports and can make jedi follow a name into site-packages and crash there.
-        Takes pre-split lines: jedi returns tens of thousands of names for a big
-        module, and splitting the source once per name measured ~850ms/file."""
-        if name_obj.type not in ("function", "class"):
-            return False
-        try:
-            line = code_lines[name_obj.line - 1]
-        except (IndexError, TypeError):
-            return False
-        return line.lstrip().startswith(("def ", "class ", "async def "))
-
-    @staticmethod
-    def _matches(name_obj, parts):
-        """True if a jedi Name matches the (possibly qualified) name-path parts."""
-        if name_obj.name != parts[-1]:
-            return False
-        if len(parts) == 1:
-            return True
-        try:
-            parent = name_obj.parent()
-        except Exception:
-            return False
-        return parent is not None and parent.name == parts[-2]
-
-    @staticmethod
-    def _span(name_obj):
-        """(start_line, end_line), 1-based, of a LOCAL definition; falls back to the
-        name's own line if jedi can't produce a range."""
-        try:
-            a = name_obj.get_definition_start_position()[0]
-            b = name_obj.get_definition_end_position()[0]
-            if a and b and b >= a:
-                return a, b
-        except Exception:
-            pass
-        return name_obj.line, name_obj.line
-
-    def _names(self, fp):
-        """jedi names + source for one file, cached by (path, mtime). An agent edits
-        the same file repeatedly (replace, test, re-replace); each jedi parse of a big
-        module costs 100ms+, so a re-locate in an unchanged file must not re-pay it.
-        Our own _apply rewrites the file, which changes its mtime and evicts."""
-        try:
-            mt = os.path.getmtime(fp)
-        except OSError:
-            mt = None
-        hit = self._names_cache.get(fp)
-        if hit is not None and hit[0] == mt:
-            return hit[1], hit[2]
-        s, code = self._script(fp)
-        names = s.get_names(all_scopes=True, definitions=True, references=False)
-        if len(self._names_cache) >= _NAMES_CACHE_MAX:
-            self._names_cache.pop(next(iter(self._names_cache)))
-        self._names_cache[fp] = (mt, names, code)
-        return names, code
-
-    def _find_defs(self, parts, path=None, should_stop=None, files=None):
-        """Definitions (function/class) matching the name path. Only files that
-        could define the name are jedi-parsed (fast prefilter); errors on any
-        single file or symbol are swallowed so one bad file can't break the search.
-        `files` short-circuits the prefilter when the caller already ran it."""
-        hits = []
-        if files is None:
-            files = self._candidate_files(parts[-1], path, should_stop)
-        for fp in files:
-            if should_stop and should_stop():
-                break
-            try:
-                names, code = self._names(fp)
-            except Exception:   # jedi can raise KeyError/RecursionError/etc.
-                continue
-            code_lines = code.splitlines()
-            for n in names:
-                try:
-                    # name equality first: it filters ~all of a big module's names
-                    # before the (comparatively pricey) definition-line check runs
-                    if self._matches(n, parts) and self._is_def(code_lines, n):
-                        hits.append((n, fp, code))
-                except Exception:
-                    continue
-        return hits
+    def _repomap(self):
+        """The repo map rooted at OUR root — normally the cwd-keyed singleton (shared
+        warm cache); a private instance only when the roots diverge (tests)."""
+        from . import repomap
+        svc = repomap.service()
+        if svc.root == self.root:
+            return svc
+        if self._rm is None:
+            self._rm = repomap.RepoMap(self.root)
+        return self._rm
 
     def _rel(self, p):
         try:
@@ -214,12 +56,35 @@ class SymbolService:
         except ValueError:
             return p
 
-    def _disambig(self, name, hits):
-        opts = "\n".join(f"  {self._rel(fp)}:{n.line}  {n.full_name}"
-                         for n, fp, _ in hits[:_DISAMBIG_MAX_LINES])
-        if len(hits) > _DISAMBIG_MAX_LINES:
-            opts += f"\n  … (+{len(hits) - _DISAMBIG_MAX_LINES} more)"
-        return f"[{len(hits)} symbols named '{name}'; pass path= to disambiguate:]\n{opts}"
+    @staticmethod
+    def _label(tag):
+        return ".".join(tag.scope + (tag.name,))
+
+    def _disambig(self, name, tags):
+        opts = "\n".join(f"  {t.rel}:{t.line}  {t.kind} {self._label(t)}"
+                         for t in tags[:_DISAMBIG_MAX_LINES])
+        if len(tags) > _DISAMBIG_MAX_LINES:
+            opts += f"\n  … (+{len(tags) - _DISAMBIG_MAX_LINES} more)"
+        return f"[{len(tags)} symbols named '{name}'; pass path= to disambiguate:]\n{opts}"
+
+    def _locate_one(self, name, path, should_stop=None):
+        """Resolve `name` (optionally within `path`) to one (start, end, file, code,
+        label) splice spec, or (None, error-message)."""
+        try:
+            tags = self._repomap()._find_defs(name, path, should_stop)
+        except Exception:   # a broken map must degrade to "not found", not a crash
+            tags = []
+        if len(tags) > 1 and path is None:
+            return None, self._disambig(name, tags)
+        if not tags:
+            return None, f"[symbol not found: {name}]"
+        t = tags[0]
+        try:
+            with open(t.path, errors="replace") as f:
+                code = f.read()
+        except OSError:
+            return None, f"[could not read {t.rel}]"
+        return (t.line, t.end_line, t.path, code, self._label(t)), None
 
     # -- edit -------------------------------------------------------------
 
@@ -241,7 +106,6 @@ class SymbolService:
                     "re-send the complete definition.)]")
         with open(fp, "w") as f:
             f.write(text)
-        self._names_cache.pop(fp, None)  # mtime would evict anyway; don't rely on it
         diff = [d for d in difflib.unified_diff(old_block, new_lines, lineterm="", n=1)
                 if not d.startswith(("---", "+++", "@@"))]
         adds = sum(d.startswith("+") for d in diff)
@@ -251,88 +115,14 @@ class SymbolService:
         if warn:
             result += warn
         drift = syntaxgate.drift_warn(fp, code, text)
-        return result + drift if drift else result
-
-    # -- locate: jedi for .py, tree-sitter tags for everything else --------
-
-    def _repomap(self):
-        """The repo map rooted at OUR root — normally the cwd-keyed singleton (shared
-        warm cache); a private instance only when the roots diverge (tests)."""
-        from . import repomap
-        svc = repomap.service()
-        if svc.root == self.root:
-            return svc
-        if self._rm is None:
-            self._rm = repomap.RepoMap(self.root)
-        return self._rm
-
-    def _ts_locate(self, name, path, should_stop=None):
-        """Non-Python definitions of `name` from the tree-sitter repo map, as
-        (start, end, path, code, label) splice specs. The map's `line`/`end_line`
-        spans are what view_symbol shows, so an edit replaces what was viewed."""
-        try:
-            tags = self._repomap()._find_defs(name, path, should_stop)
-        except Exception:   # a broken map must degrade to "not found", not a crash
-            return []
-        out = []
-        for t in tags:
-            if t.path.endswith(".py"):
-                continue    # jedi owns Python — scope-aware and qualified-path capable
-            try:
-                with open(t.path, errors="replace") as f:
-                    code = f.read()
-            except OSError:
-                continue
-            out.append((t.line, t.end_line, t.path, code, f"{t.kind} {t.name}"))
-        return out
-
-    def _locate_one(self, name, path, should_stop=None):
-        """Resolve `name` (optionally within `path`) to one (start, end, file, code,
-        label) splice spec, or (None, error-message). Python resolves via jedi;
-        misses fall through to the tree-sitter map so every language the map parses
-        is editable. A name found in BOTH resolves to Python (the pre-existing
-        behavior when other languages were invisible)."""
-        parts = _norm_path(name)
-        py_target = path is None or path.endswith(".py")
-        hits: list = []
-        if py_target:
-            for _attempt in (0, 1):
-                cands = self._candidate_files(parts[-1], path, should_stop)
-                if path is None and len(cands) > _MAX_DEF_FILES:
-                    # A name defined in this many files can't be located without
-                    # path= anyway; jedi-parsing every definer just to say
-                    # "ambiguous" measured 60s for 'forward' on the pytorch clone.
-                    listing = "\n".join(f"  {self._rel(fp)}"
-                                        for fp in cands[:_DISAMBIG_MAX_LINES])
-                    if len(cands) > _DISAMBIG_MAX_LINES:
-                        listing += f"\n  … (+{len(cands) - _DISAMBIG_MAX_LINES} more)"
-                    return None, (f"['{parts[-1]}' is defined in {len(cands)} files; "
-                                  f"pass path= to pick one:]\n{listing}")
-                hits = self._find_defs(parts, path, should_stop, files=cands)
-                if hits or path is not None or time.monotonic() - self._py_files_at <= 1.0:
-                    break
-                # The symbol may live in a file created after the cached walk (the
-                # TTL trades that staleness for burst speed). Before reporting
-                # not-found, re-walk once — only genuine misses pay this.
-                self._py_files_at = 0.0
-        if hits:
-            if len(hits) > 1 and path is None:
-                return None, self._disambig(name, hits)
-            n, fp, code = hits[0]
-            a, b = self._span(n)
-            return (a, b, fp, code, n.full_name or name), None
-        if path is None or not py_target:
-            ts = self._ts_locate(parts[-1], path, should_stop)
-            if len(ts) > 1 and path is None:
-                opts = "\n".join(f"  {self._rel(fp)}:{a}  {label}"
-                                 for a, _b, fp, _c, label in ts[:_DISAMBIG_MAX_LINES])
-                if len(ts) > _DISAMBIG_MAX_LINES:
-                    opts += f"\n  … (+{len(ts) - _DISAMBIG_MAX_LINES} more)"
-                return None, (f"[{len(ts)} symbols named '{parts[-1]}'; pass path= "
-                              f"to disambiguate:]\n{opts}")
-            if ts:
-                return ts[0], None
-        return None, f"[symbol not found: {name}]"
+        if drift:
+            result += drift
+        from . import levers, lsp
+        if levers.enabled("post_edit_diagnostics"):
+            # The semantic tier above syntaxgate: the language server's typecheck of
+            # the landed edit ("" when no server is warm for this language).
+            result += lsp.diagnostics_note(fp)
+        return result
 
     def replace_symbol(self, name: str, new: str, path=None, should_stop=None) -> str:
         hit, err = self._locate_one(name, path, should_stop)

--- a/src/chad/tools.py
+++ b/src/chad/tools.py
@@ -21,7 +21,7 @@ import threading
 import time
 from typing import Any
 
-from . import config, levers, repomap, symbols, syntaxgate
+from . import config, levers, lsp, repomap, symbols, syntaxgate
 from .ignore import IGNORE_DIRS, slash_wrapped
 
 # Directories never worth walking: huge, generated, or VCS internals. The canonical set
@@ -874,7 +874,13 @@ def _apply_edit(path: str, before: str, after: str, note: str,
     if warn:
         result += warn
     drift = syntaxgate.drift_warn(path, before, after)
-    return result + drift if drift else result
+    if drift:
+        result += drift
+    if levers.enabled("post_edit_diagnostics"):
+        # The semantic tier above syntaxgate: the language server's typecheck of the
+        # landed edit ("" when no server is warm for this language).
+        result += lsp.diagnostics_note(path)
+    return result
 
 
 def tool_edit(path: str, old: str, new: str) -> str:
@@ -1671,7 +1677,7 @@ DISPATCH = {
                                          a.get("context", 0), should_stop=ss),
     # Symbolic code tools. READS go through the tree-sitter backend (repomap) — it's
     # language-agnostic and the repo_map gives a ranked skeleton for cheap navigation.
-    # EDITS stay on the jedi backend (symbols), the proven Python symbol editor.
+    # EDITS (symbols) resolve through the same tags, so viewed span == edited span.
     "repo_map": lambda a, ss=None: repomap.service().repo_map(
         a.get("budget", 1500), a.get("focus"), should_stop=ss),
     "overview": lambda a, ss=None: repomap.service().overview(a["path"], should_stop=ss),
@@ -1679,6 +1685,8 @@ DISPATCH = {
         a["name"], a.get("path"), should_stop=ss),
     "find_symbol": lambda a, ss=None: repomap.service().find_symbol(a["name"], should_stop=ss),
     "find_refs": lambda a, ss=None: repomap.service().find_refs(
+        a["name"], a.get("path"), should_stop=ss),
+    "hover": lambda a, ss=None: repomap.service().hover(
         a["name"], a.get("path"), should_stop=ss),
     "replace_symbol": lambda a, ss=None: symbols.service().replace_symbol(
         a["name"], a["new"], a.get("path"), should_stop=ss),
@@ -2050,6 +2058,23 @@ SCHEMAS: list[dict[str, Any]] = [
     {
         "type": "function",
         "function": {
+            "name": "hover",
+            "description": "The resolved TYPE SIGNATURE (and docs) of one symbol, from the "
+                           "language server — read a type in one line instead of opening its "
+                           "file. Name may be 'Class/method'; pass path to disambiguate.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Symbol or 'Class/method'."},
+                    "path": {"type": "string", "description": "Optional file to disambiguate."},
+                },
+                "required": ["name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "replace_symbol",
             "description": "Replace the ENTIRE source of one function/class/method with new code "
                            "(found by name, not text matching — robust to whitespace). `new` is "
@@ -2116,7 +2141,7 @@ SCHEMAS: list[dict[str, Any]] = [
 # between arms and the agent's render path calls active_schemas() each turn. SCHEMAS
 # itself stays the full list (name lookups / required-arg validation need every tool).
 _SYMBOLIC = {"repo_map", "overview", "view_symbol", "find_symbol", "find_refs",
-             "replace_symbol", "insert_symbol", "rename_symbol"}
+             "hover", "replace_symbol", "insert_symbol", "rename_symbol"}
 
 
 def _activate_skill_schema(names):

--- a/tests/fixtures/polyglot/bash/app.sh
+++ b/tests/fixtures/polyglot/bash/app.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+source ./lib.sh
+
+process() {
+  helper "$1"
+}
+
+run() {
+  engine_process "$(process 1)"
+}

--- a/tests/fixtures/polyglot/bash/lib.sh
+++ b/tests/fixtures/polyglot/bash/lib.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+MODE=fast
+
+process() {
+  echo "lib:$1"
+}
+
+engine_process() {
+  process "$1"
+}
+
+helper() {
+  echo "$(($1 + 1))"
+}

--- a/tests/fixtures/polyglot/c/app.c
+++ b/tests/fixtures/polyglot/c/app.c
@@ -1,0 +1,5 @@
+#include "lib.h"
+
+static int process(int x) { return helper(x); }
+
+int run(void) { return engine_process(process(1)); }

--- a/tests/fixtures/polyglot/c/lib.c
+++ b/tests/fixtures/polyglot/c/lib.c
@@ -1,0 +1,7 @@
+#include "lib.h"
+
+static int process(int x) { return x - 1; }
+
+int engine_process(int x) { return process(x) * 2; }
+
+int helper(int x) { return x + 1; }

--- a/tests/fixtures/polyglot/c/lib.h
+++ b/tests/fixtures/polyglot/c/lib.h
@@ -1,0 +1,2 @@
+int engine_process(int x);
+int helper(int x);

--- a/tests/fixtures/polyglot/cpp/app.cpp
+++ b/tests/fixtures/polyglot/cpp/app.cpp
@@ -1,0 +1,8 @@
+#include "lib.hpp"
+
+int process(int x) { return helper(x); }
+
+int run() {
+    Engine e;
+    return e.process(process(1));
+}

--- a/tests/fixtures/polyglot/cpp/lib.cpp
+++ b/tests/fixtures/polyglot/cpp/lib.cpp
@@ -1,0 +1,5 @@
+#include "lib.hpp"
+
+int Engine::process(int x) { return x * 2; }
+
+int helper(int x) { return x + 1; }

--- a/tests/fixtures/polyglot/cpp/lib.hpp
+++ b/tests/fixtures/polyglot/cpp/lib.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+class Engine {
+public:
+    int process(int x);
+};
+
+int helper(int x);

--- a/tests/fixtures/polyglot/csharp/App.cs
+++ b/tests/fixtures/polyglot/csharp/App.cs
@@ -1,0 +1,15 @@
+namespace Fixture
+{
+    public class App
+    {
+        static int Process(int x)
+        {
+            return Util.Helper(x);
+        }
+
+        static int Run()
+        {
+            return new Engine().Process(Process(1));
+        }
+    }
+}

--- a/tests/fixtures/polyglot/csharp/Lib.cs
+++ b/tests/fixtures/polyglot/csharp/Lib.cs
@@ -1,0 +1,18 @@
+namespace Fixture
+{
+    public class Engine
+    {
+        public int Process(int x)
+        {
+            return x * 2;
+        }
+    }
+
+    public static class Util
+    {
+        public static int Helper(int x)
+        {
+            return x + 1;
+        }
+    }
+}

--- a/tests/fixtures/polyglot/go/app.go
+++ b/tests/fixtures/polyglot/go/app.go
@@ -1,0 +1,10 @@
+package fixture
+
+func Process(x int) int {
+	return Helper(x)
+}
+
+func Run() int {
+	e := Engine{}
+	return e.Process(Process(1))
+}

--- a/tests/fixtures/polyglot/go/lib.go
+++ b/tests/fixtures/polyglot/go/lib.go
@@ -1,0 +1,11 @@
+package fixture
+
+type Engine struct{}
+
+func (e Engine) Process(x int) int {
+	return x * 2
+}
+
+func Helper(x int) int {
+	return x + 1
+}

--- a/tests/fixtures/polyglot/java/App.java
+++ b/tests/fixtures/polyglot/java/App.java
@@ -1,0 +1,9 @@
+public class App {
+    static int process(int x) {
+        return Util.helper(x);
+    }
+
+    static int run() {
+        return new Engine().process(process(1));
+    }
+}

--- a/tests/fixtures/polyglot/java/Engine.java
+++ b/tests/fixtures/polyglot/java/Engine.java
@@ -1,0 +1,11 @@
+public class Engine {
+    public int process(int x) {
+        return x * 2;
+    }
+}
+
+class Util {
+    static int helper(int x) {
+        return x + 1;
+    }
+}

--- a/tests/fixtures/polyglot/javascript/app.js
+++ b/tests/fixtures/polyglot/javascript/app.js
@@ -1,0 +1,9 @@
+import { Engine, helper } from "./lib.js";
+
+export function process(x) {
+  return helper(x);
+}
+
+export function run() {
+  return new Engine().process(process(1));
+}

--- a/tests/fixtures/polyglot/javascript/lib.js
+++ b/tests/fixtures/polyglot/javascript/lib.js
@@ -1,0 +1,9 @@
+export class Engine {
+  process(x) {
+    return x * 2;
+  }
+}
+
+export function helper(x) {
+  return x + 1;
+}

--- a/tests/fixtures/polyglot/kotlin/App.kt
+++ b/tests/fixtures/polyglot/kotlin/App.kt
@@ -1,0 +1,7 @@
+fun process(x: Int): Int {
+    return helper(x)
+}
+
+fun run(): Int {
+    return Engine().process(process(1))
+}

--- a/tests/fixtures/polyglot/kotlin/Lib.kt
+++ b/tests/fixtures/polyglot/kotlin/Lib.kt
@@ -1,0 +1,9 @@
+class Engine {
+    fun process(x: Int): Int {
+        return x * 2
+    }
+}
+
+fun helper(x: Int): Int {
+    return x + 1
+}

--- a/tests/fixtures/polyglot/php/app.php
+++ b/tests/fixtures/polyglot/php/app.php
@@ -1,0 +1,14 @@
+<?php
+
+require_once "lib.php";
+
+function process($x)
+{
+    return helper($x);
+}
+
+function run()
+{
+    $e = new Engine();
+    return $e->process(process(1));
+}

--- a/tests/fixtures/polyglot/php/lib.php
+++ b/tests/fixtures/polyglot/php/lib.php
@@ -1,0 +1,14 @@
+<?php
+
+class Engine
+{
+    public function process($x)
+    {
+        return $x * 2;
+    }
+}
+
+function helper($x)
+{
+    return $x + 1;
+}

--- a/tests/fixtures/polyglot/python/app.py
+++ b/tests/fixtures/polyglot/python/app.py
@@ -1,0 +1,9 @@
+from lib import Engine, helper
+
+
+def process(x):
+    return helper(x)
+
+
+def run():
+    return Engine().process(process(1))

--- a/tests/fixtures/polyglot/python/lib.py
+++ b/tests/fixtures/polyglot/python/lib.py
@@ -1,0 +1,7 @@
+class Engine:
+    def process(self, x):
+        return x * 2
+
+
+def helper(x):
+    return x + 1

--- a/tests/fixtures/polyglot/ruby/app.rb
+++ b/tests/fixtures/polyglot/ruby/app.rb
@@ -1,0 +1,9 @@
+require_relative "lib"
+
+def process(x)
+  helper(x)
+end
+
+def run
+  Engine.new.process(process(1))
+end

--- a/tests/fixtures/polyglot/ruby/lib.rb
+++ b/tests/fixtures/polyglot/ruby/lib.rb
@@ -1,0 +1,9 @@
+class Engine
+  def process(x)
+    x * 2
+  end
+end
+
+def helper(x)
+  x + 1
+end

--- a/tests/fixtures/polyglot/rust/app.rs
+++ b/tests/fixtures/polyglot/rust/app.rs
@@ -1,0 +1,9 @@
+use crate::lib::{helper, Engine};
+
+pub fn process(x: i32) -> i32 {
+    helper(x)
+}
+
+pub fn run() -> i32 {
+    Engine.process(process(1))
+}

--- a/tests/fixtures/polyglot/rust/lib.rs
+++ b/tests/fixtures/polyglot/rust/lib.rs
@@ -1,0 +1,11 @@
+pub struct Engine;
+
+impl Engine {
+    pub fn process(&self, x: i32) -> i32 {
+        x * 2
+    }
+}
+
+pub fn helper(x: i32) -> i32 {
+    x + 1
+}

--- a/tests/fixtures/polyglot/typescript/app.ts
+++ b/tests/fixtures/polyglot/typescript/app.ts
@@ -1,0 +1,9 @@
+import { Engine, helper } from "./lib";
+
+export function process(x: number): number {
+  return helper(x);
+}
+
+export function run(): number {
+  return new Engine().process(process(1));
+}

--- a/tests/fixtures/polyglot/typescript/lib.ts
+++ b/tests/fixtures/polyglot/typescript/lib.ts
@@ -1,0 +1,9 @@
+export class Engine {
+  process(x: number): number {
+    return x * 2;
+  }
+}
+
+export function helper(x: number): number {
+  return x + 1;
+}

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -6,7 +6,7 @@ no module's *effective* skip set. repomap keeps its 3 extra dirs; every other mo
 keeps exactly the base 9.
 """
 
-from chad import repomap, skills, symbols, tools
+from chad import repomap, skills, tools
 
 EXPECTED_BARE = (".git", "node_modules", "__pycache__", ".venv", "venv",
                  ".mypy_cache", ".pytest_cache", "dist", "build")
@@ -17,8 +17,8 @@ def test_ignore_sets_unchanged():
     assert tools.IGNORE_DIRS == EXPECTED_BARE
     assert tools._SKIP_DIRS == tuple(f"/{d}/" for d in EXPECTED_BARE)
     assert skills._SKIP_DIRS == set(EXPECTED_BARE)
-    # symbols prunes bare names during its os.walk now (no slash-wrapped post-filter)
-    assert symbols.IGNORE_DIRS == EXPECTED_BARE
+    # symbols no longer walks the tree at all — it resolves through repomap's
+    # file scan, so repomap's skip set is the symbol editor's skip set too
     assert repomap._SKIP_NAMES == EXPECTED_REPOMAP_NAMES
 
 

--- a/tests/test_lever_bite.py
+++ b/tests/test_lever_bite.py
@@ -809,6 +809,29 @@ def test_late_continue_replenish(monkeypatch):
     assert guardrails.replenish_continue(900, 500, 2) is False
 
 
+# === ctxengine: post-edit language-server diagnostics ======================
+
+def test_post_edit_diagnostics_bite(tmp_path, monkeypatch):
+    """The same landed edit carries the typecheck note with the lever on and is
+    byte-identical to the pre-lever result with it off."""
+    from chad import lsp
+    n = bite("post_edit_diagnostics")
+    monkeypatch.setattr(lsp, "diagnostics_note",
+                        lambda path: "\n[typecheck — 1 error(s) (language server):"
+                                     "\n  line 1: boom]")
+    p = str(tmp_path / "m.py")
+
+    def edit(tag):
+        with open(p, "w") as f:
+            f.write("x = 1\n")
+        return tools._apply_edit(p, "x = 1\n", f"x = {tag}\n", "")
+
+    on(monkeypatch)
+    assert "typecheck" in edit(2)
+    off(monkeypatch, n)
+    assert "typecheck" not in edit(3)
+
+
 # === the coverage contract =================================================
 
 def test_every_registered_lever_has_a_bite_test():

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -1,115 +1,315 @@
 """Pin lsp.py's degradation contract and operational guardrails.
 
-The precision layer ships in the optional `lsp` extra (serena-agent), so nothing
-here may require a live language server or the solidlsp package: extension routing,
-graceful absence, the clangd compile-database gate, the decorative never-spawn
-policy, and RSS-based recycling are all testable with fakes.
+The precision layer ships in the base install but its language servers live
+outside the wheel (PATH / uvx / npx), so nothing here may require a live server:
+extension routing, graceful absence, the honestly-unsupported rows, the clangd
+compile-database gate, the decorative never-spawn policy, dead-server drop, and
+RSS-based recycling are all testable with fakes. Protocol mechanics live in
+test_lspclient.py; a real pyright run lives in test_lsp_live.py.
 """
 
-import sys
+import os
 
-from chad import lsp
-from chad.lsp import LspService, lang_for
+from chad import lsp, lspservers
+from chad.lsp import LspService
+from chad.lspservers import lang_for
 
 
-class _FakeServer:
-    """Stands in for a running SolidLanguageServer."""
+class _FakeClient:
+    """Stands in for a running lspclient.LspClient."""
 
-    def __init__(self, locs=()):
+    def __init__(self, locs=(), alive=True):
         self.locs = list(locs)
         self.stopped = False
         self.requests = 0
+        self._alive = alive
 
-    def request_references(self, rel, row, col):
+    def sync_doc(self, path, language_id, text=None):
+        return "file://" + path
+
+    def references(self, path, row, col, timeout=5.0, include_declaration=False):
         self.requests += 1
+        if not self._alive:
+            raise RuntimeError("server gone")
         return self.locs
 
-    def stop(self):
+    def definition(self, path, row, col, timeout=5.0):
+        return [(p, ln) for p, ln, _c in self.locs]
+
+    def shutdown(self):
         self.stopped = True
 
+    def alive(self):
+        return self._alive
 
-def test_lang_for_known_and_unknown():
-    assert lang_for("x.py") == "PYTHON"
-    assert lang_for("sub/dir/x.PY") == "PYTHON"  # extension match is case-insensitive
+    @property
+    def pid(self):
+        return 4242
+
+
+def test_lang_for_owns_its_identities():
+    assert lang_for("x.py") == "python"
+    assert lang_for("sub/dir/x.PY") == "python"  # extension match is case-insensitive
+    # chad's own language identity, not a vendor enum: .js is javascript (the
+    # typescript SERVER handles it, but the language is named for what it is),
+    # and .c is c, not "CPP".
+    assert lang_for("a.js") == "javascript"
+    assert lang_for("a.c") == "c"
+    assert lang_for("a.cpp") == "cpp"
     assert lang_for("x.unknownext") is None
     assert lang_for("no_extension") is None
+    # languages that share a server share a process key
+    assert lspservers.spec_for("javascript").server_key \
+        == lspservers.spec_for("typescript").server_key
+    assert lspservers.spec_for("c").server_key == lspservers.spec_for("cpp").server_key
 
 
-def test_degrades_without_solidlsp(tmp_path, monkeypatch):
-    # None in sys.modules makes `from solidlsp import ...` raise ImportError,
-    # exactly like a default (no-extra) install where the package is absent.
-    monkeypatch.setitem(sys.modules, "solidlsp", None)
+def test_degrades_without_any_server(tmp_path, monkeypatch):
+    # No resolvable command == a machine with no server installed: every request
+    # degrades to None (tree-sitter fallback), nothing raises, stop() is a no-op.
+    monkeypatch.setattr(lspservers, "resolve_commands", lambda spec: [])
     svc = LspService(str(tmp_path))
     assert svc.available("f.py") is False
     assert svc.references("f.py", 0, 0) is None
     assert svc.definition("f.py", 0, 0) is None
+    assert svc.hover("f.py", 0, 0) is None
+    assert svc.diagnostics_after_edit("f.py") is None
     svc.stop()  # no server was created; must be a no-op, not an error
+
+
+def test_unsupported_language_refuses_honestly(tmp_path):
+    """java/csharp rows declare themselves unsupported (empty commands) — the
+    registry SAYS so instead of half-supporting a bootstrap chad doesn't own."""
+    svc = LspService(str(tmp_path))
+    assert svc.references("App.java", 0, 0) is None
+    assert svc._servers.get("jdtls", "untried") is None  # cached refusal, no retry
+    spec = lspservers.spec_for("java")
+    assert spec.commands == () and "jdtls" in spec.unsupported
+    svc.stop()
 
 
 def test_cpp_gated_on_compile_db(tmp_path, monkeypatch):
     """Without a compilation database clangd returns confidently-empty cross-file
     results, so the server must not start at all (callers get the honestly-labeled
-    tree-sitter fallback). The gate sits before the solidlsp import, so it holds on
-    a default install too."""
-    monkeypatch.setitem(sys.modules, "solidlsp", None)
+    tree-sitter fallback)."""
     svc = LspService(str(tmp_path))
     assert svc.references("main.cpp", 0, 0) is None
-    assert svc._servers.get("CPP", "untried") is None  # cached refusal, no retry
+    assert svc._servers.get("clangd", "untried") is None  # cached refusal, no retry
 
-    # with a compile db the gate opens (and then absence of solidlsp degrades as usual)
+    # with a compile db the gate opens (and an unresolvable command degrades as usual)
     (tmp_path / "compile_commands.json").write_text("[]")
+    monkeypatch.setattr(lspservers, "resolve_commands", lambda spec: [])
     svc2 = LspService(str(tmp_path))
-    assert svc2.references("main.cpp", 0, 0) is None  # solidlsp absent, not gated
+    assert svc2.references("main.cpp", 0, 0) is None  # command absent, not gated
     svc.stop()
     svc2.stop()
 
 
-def test_decorative_never_spawns_foreign_server(tmp_path):
-    """references_decorative must not pay a server start for decoration: an
-    un-started non-Python language is refused without ever touching _server()."""
+def test_typescript_gated_on_project_file(tmp_path, monkeypatch):
+    """Same honesty rule as clangd: TS without a tsconfig/jsconfig returns
+    confidently-empty cross-file results (measured on the TS7 native LSP), so the
+    server must not start at all."""
+    svc = LspService(str(tmp_path))
+    assert svc.references("app.ts", 0, 0) is None
+    assert svc._servers.get("typescript", "untried") is None
+    (tmp_path / "tsconfig.json").write_text("{}")
+    monkeypatch.setattr(lspservers, "resolve_commands", lambda spec: [])
+    svc2 = LspService(str(tmp_path))
+    assert svc2.references("app.ts", 0, 0) is None    # command absent, not gated
+    svc.stop()
+    svc2.stop()
+
+
+def test_decorative_never_spawns_expensive_server(tmp_path):
+    """references_decorative must not pay a server start for decoration unless the
+    registry marks the server cheap (decorative_ok): an un-started rust/ts server
+    is refused without ever touching _server()."""
     svc = LspService(str(tmp_path))
 
-    def boom(lang):
-        if lang in svc._servers:  # cache hits are fine; *starting* one is the bug
-            return svc._servers[lang]
-        raise AssertionError(f"decorative call tried to start a {lang} server")
+    def boom(spec):
+        if spec.server_key in svc._servers:  # cache hits are fine; *starting* is the bug
+            return svc._servers[spec.server_key]
+        raise AssertionError(f"decorative call tried to start {spec.server_key}")
 
     svc._server = boom
     assert svc.references_decorative("x.rs", 0, 0) is None
     assert svc.references_decorative("x.ts", 0, 0) is None
 
     # but an already-running foreign server IS used
-    fake = _FakeServer(locs=[{"relativePath": "user.rs",
-                              "range": {"start": {"line": 3, "character": 4}}}])
-    svc._servers["RUST"] = fake
-    svc._recycle_if_bloated = lambda lang, srv: None
+    fake = _FakeClient(locs=[(os.path.join(str(tmp_path), "user.rs"), 4, 5)])
+    svc._servers["rust-analyzer"] = fake
+    svc._recycle_if_bloated = lambda key, cli: None
     assert svc.references_decorative("x.rs", 0, 0) == [("user.rs", 4, 5)]
     assert fake.requests == 1
     svc.stop()
+
+
+def test_edit_diagnostics_never_spawn_a_server(tmp_path):
+    """An edit result is on the interactive path: diagnostics_after_edit must not
+    start ANY server — not even the registry-cheap python one. (A cold uvx fetch
+    inside an edit round trip, or inside every edit test of the fast gate, is the
+    stall this pins out.)"""
+    svc = LspService(str(tmp_path))
+
+    def boom(spec):
+        raise AssertionError(f"edit diagnostics tried to start {spec.server_key}")
+
+    svc._server = boom
+    assert svc.diagnostics_after_edit("f.py") is None
+    assert svc.diagnostics_after_edit("app.ts") is None
+    svc.stop()
+
+
+def test_python_is_decorative_ok():
+    """pyright is the one server proven cheap enough to spawn for a hint (~0.9s,
+    flat across repo sizes) — the registry must keep saying so."""
+    assert lspservers.spec_for("python").decorative_ok is True
+    assert lspservers.spec_for("cpp").decorative_ok is False
+    assert lspservers.spec_for("rust").decorative_ok is False
 
 
 def test_recycle_on_rss_cap(tmp_path, monkeypatch):
     """A server whose process tree exceeds the RSS cap is stopped and forgotten
     after the request, so the next call starts fresh instead of the bloated server
     starving the GPU allocator."""
-    class _PidServer(_FakeServer):
-        class server:  # noqa: N801 - mimic solidlsp's srv.server.process.pid shape
-            class process:
-                pid = 4242
-
-    fat = _PidServer(locs=[])
+    fat = _FakeClient(locs=[])
     svc = LspService(str(tmp_path))
-    svc._servers["PYTHON"] = fat
+    svc._servers["pyright"] = fat
     monkeypatch.setattr(lsp, "_tree_rss_mb", lambda pid: lsp._MAX_RSS_MB + 1)
     assert svc.references("f.py", 0, 0) == []
     assert fat.stopped is True
-    assert "PYTHON" not in svc._servers  # forgotten -> next request restarts
+    assert "pyright" not in svc._servers  # forgotten -> next request restarts
 
     # under the cap, the server is left alone
-    slim = _PidServer(locs=[])
-    svc._servers["PYTHON"] = slim
+    slim = _FakeClient(locs=[])
+    svc._servers["pyright"] = slim
     monkeypatch.setattr(lsp, "_tree_rss_mb", lambda pid: 100)
     assert svc.references("f.py", 0, 0) == []
     assert slim.stopped is False
-    assert svc._servers["PYTHON"] is slim
+    assert svc._servers["pyright"] is slim
+    svc.stop()
+
+
+def test_dead_server_is_dropped(tmp_path, monkeypatch):
+    """A request against a dead server degrades to None AND forgets the server, so
+    the next request can start a fresh one instead of failing forever."""
+    dead = _FakeClient(alive=False)
+    svc = LspService(str(tmp_path))
+    svc._servers["pyright"] = dead
+    monkeypatch.setattr(lsp, "_tree_rss_mb", lambda pid: 0)
+    assert svc.references("f.py", 0, 0) is None
+    assert "pyright" not in svc._servers
+    svc.stop()
+
+
+class _FakeDiagService:
+    def __init__(self, diags):
+        self._diags = diags
+        self.root = os.path.abspath(os.getcwd())  # so service() won't rebind
+
+    def diagnostics_after_edit(self, path):
+        return self._diags
+
+
+def _with_service(monkeypatch, svc):
+    monkeypatch.setattr(lsp, "_SERVICE", svc)
+
+
+def test_diagnostics_note_formats_errors_only(monkeypatch):
+    _with_service(monkeypatch, _FakeDiagService(
+        [("error", 3, "Type \"str\" is not assignable to \"int\"\nlong detail"),
+         ("warning", 9, "unused variable"),
+         ("error", 7, "x" * 500)]))
+    note = lsp.diagnostics_note("f.py")
+    assert "2 error(s)" in note, note
+    assert "line 3: Type" in note and "line 7: xxx" in note
+    assert "unused variable" not in note          # warnings are edit-time noise
+    assert "long detail" not in note              # first line of each message only
+    assert len(note) < 500                        # message truncation held
+
+
+def test_diagnostics_note_caps_at_five(monkeypatch):
+    _with_service(monkeypatch, _FakeDiagService(
+        [("error", i, f"e{i}") for i in range(1, 9)]))
+    note = lsp.diagnostics_note("f.py")
+    assert "8 error(s)" in note and "(+3 more)" in note, note
+    assert "line 5:" in note and "line 6:" not in note
+
+
+def test_diagnostics_note_silent_paths(monkeypatch):
+    # no warm server / clean bill / warnings only / disabled -> all empty
+    _with_service(monkeypatch, _FakeDiagService(None))
+    assert lsp.diagnostics_note("f.py") == ""
+    _with_service(monkeypatch, _FakeDiagService([]))
+    assert lsp.diagnostics_note("f.py") == ""
+    _with_service(monkeypatch, _FakeDiagService([("warning", 1, "meh")]))
+    assert lsp.diagnostics_note("f.py") == ""
+    _with_service(monkeypatch, _FakeDiagService([("error", 1, "real")]))
+    monkeypatch.setattr(lsp, "_DIAG_TIMEOUT_S", 0.0)
+    assert lsp.diagnostics_note("f.py") == ""     # CHAD_LSP_DIAG_TIMEOUT=0 kill switch
+
+
+def test_post_edit_diagnostics_reach_symbol_edits(tmp_path, monkeypatch):
+    """The lever wires the typecheck note into replace_symbol results (and stays
+    out when disabled)."""
+    from chad.symbols import SymbolService
+    fp = tmp_path / "m.py"
+    fp.write_text("def f():\n    return 1\n")
+    monkeypatch.setattr(lsp, "diagnostics_note",
+                        lambda path: "\n[typecheck — 1 error(s) (language server):"
+                                     "\n  line 2: boom]")
+    svc = SymbolService(str(tmp_path))
+    res = svc.replace_symbol("f", "def f():\n    return 2", path=str(fp))
+    assert res.startswith("[replaced") and "typecheck" in res, res
+
+    monkeypatch.setenv("CHAD_DISABLE", "post_edit_diagnostics")  # read per call
+    fp2 = tmp_path / "n.py"
+    fp2.write_text("def g():\n    return 1\n")
+    res2 = svc.replace_symbol("g", "def g():\n    return 3", path=str(fp2))
+    assert "typecheck" not in res2, res2
+
+
+def test_hover_tool_routes_by_symbol_name(tmp_path, monkeypatch):
+    """repomap.hover: name -> definition position -> language-server hover text;
+    honest fallback when no server speaks for the language."""
+    from chad.repomap import RepoMap
+    (tmp_path / "m.py").write_text("def helper(x):\n    return x\n")
+    rm = RepoMap(str(tmp_path))
+    rm._disk_checked = True
+
+    class _HoverSvc:
+        def __init__(self):
+            self.root = os.path.abspath(os.getcwd())
+            self.asked = None
+
+        def hover(self, rel, row, col):
+            self.asked = (rel, row, col)
+            return "(function) def helper(x: int) -> int"
+
+    svc = _HoverSvc()
+    _with_service(monkeypatch, svc)
+    out = rm.hover("helper")
+    assert out.startswith("m.py:1"), out
+    assert "helper(x: int)" in out
+    assert svc.asked == ("m.py", 0, 4)   # the identifier's 0-based position
+
+    class _NoSvc:
+        root = os.path.abspath(os.getcwd())
+
+        def hover(self, rel, row, col):
+            return None
+
+    _with_service(monkeypatch, _NoSvc())
+    assert "no language server available" in rm.hover("helper")
+    assert "symbol not found" in rm.hover("nope")
+
+
+def test_rel_paths_in_results(tmp_path, monkeypatch):
+    """Absolute paths from the client come back repo-relative, matching what the
+    tree-sitter fallback prints (the model sees one path style)."""
+    fake = _FakeClient(locs=[(os.path.join(str(tmp_path), "pkg", "user.py"), 3, 7)])
+    svc = LspService(str(tmp_path))
+    svc._servers["pyright"] = fake
+    monkeypatch.setattr(lsp, "_tree_rss_mb", lambda pid: 0)
+    assert svc.references("f.py", 0, 0) == [(os.path.join("pkg", "user.py"), 3, 7)]
     svc.stop()

--- a/tests/test_lsp_live.py
+++ b/tests/test_lsp_live.py
@@ -1,0 +1,108 @@
+"""LIVE language-server tests: chad's client against a real pyright (and tsserver
+when npx is present). Guarded, not mocked — this is the first test that exercises
+the precision path end to end.
+
+Gating: pyright resolves via PATH or uvx (`uvx chad-code` guarantees uv exists, so
+this is exactly the shipped path). Without a resolvable launcher the tests skip;
+with CHAD_LSP_LIVE_REQUIRED=1 (CI) a startup failure FAILS instead of skipping —
+graceful degradation is for users, not for CI.
+"""
+
+import os
+import shutil
+
+import pytest
+
+from chad import lspservers
+from chad.lsp import LspService
+
+_REQUIRED = os.environ.get("CHAD_LSP_LIVE_REQUIRED", "") == "1"
+
+
+def _skip_or_fail(reason):
+    if _REQUIRED:
+        pytest.fail(f"live LSP required but unavailable: {reason}")
+    pytest.skip(reason)
+
+
+def _service_for(tmp_path, files, lang="python"):
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    spec = lspservers.spec_for(lang)
+    if lspservers.resolve_command(spec) is None:
+        _skip_or_fail(f"no launcher for {lang} ({spec.tier})")
+    svc = LspService(str(tmp_path))
+    return svc
+
+
+PY_LIB = "def helper(x):\n    return x + 1\n\n\ndef helper_twin(x):\n    return x\n"
+PY_APP = "from lib import helper\n\n\ndef run():\n    return helper(1)\n"
+
+
+@pytest.fixture
+def py_service(tmp_path):
+    svc = _service_for(tmp_path, {"lib.py": PY_LIB, "app.py": PY_APP})
+    yield svc
+    svc.stop()
+
+
+def test_pyright_cross_file_references(py_service):
+    # helper's identifier sits at (0-based) row 0 col 4 in lib.py
+    locs = py_service.references("lib.py", 0, 4)
+    if locs is None:
+        _skip_or_fail("pyright failed to start")
+    assert ("app.py", 5, 12) in locs or any(rel == "app.py" for rel, _l, _c in locs), locs
+    # precision, not name-match: helper_twin's references stay empty
+    twin = py_service.references("lib.py", 4, 4)
+    assert twin == [], twin
+
+
+def test_pyright_definition_and_hover(py_service):
+    # `helper` used in app.py:5 resolves to its definition in lib.py:1
+    defs = py_service.definition("app.py", 4, 11)
+    if defs is None:
+        _skip_or_fail("pyright failed to start")
+    assert ("lib.py", 1) in defs, defs
+    hover = py_service.hover("lib.py", 0, 4)
+    assert hover and "helper" in hover, hover
+
+
+def test_pyright_diagnostics_after_edit(py_service, tmp_path):
+    (tmp_path / "bad.py").write_text("def f() -> int:\n    return 'nope'\n")
+    if py_service.references("lib.py", 0, 4) is None:   # warm the server
+        _skip_or_fail("pyright failed to start")
+    diags = py_service.diagnostics_after_edit("bad.py")
+    assert diags, "expected a type error from pyright"
+    sev, line, msg = diags[0]
+    assert sev == "error" and line == 2, diags
+
+    # and a clean file gets a clean bill (empty list, not None)
+    (tmp_path / "ok.py").write_text("def g() -> int:\n    return 3\n")
+    assert py_service.diagnostics_after_edit("ok.py") == []
+
+
+TS_LIB = "export function helper(x: number): number {\n  return x + 1;\n}\n"
+TS_APP = 'import { helper } from "./lib";\n\nexport const r = helper(1);\n'
+
+
+def test_typescript_cross_file_refs_and_pull_diagnostics(tmp_path):
+    if shutil.which("typescript-language-server") is None and shutil.which("npx") is None:
+        _skip_or_fail("no typescript-language-server or npx")
+    svc = _service_for(tmp_path,
+                       {"lib.ts": TS_LIB, "app.ts": TS_APP,
+                        # the registry's honesty gate requires a project file
+                        "tsconfig.json": '{"compilerOptions": {"strict": true}}\n'},
+                       lang="typescript")
+    try:
+        locs = svc.references("lib.ts", 0, 16)
+        if locs is None:
+            _skip_or_fail("typescript server failed to start")
+        assert any(rel == "app.ts" for rel, _l, _c in locs), locs
+        # TS7's native LSP has no push diagnostics — this exercises the pull path
+        (tmp_path / "bad.ts").write_text("export const n: number = 'nope';\n")
+        diags = svc.diagnostics_after_edit("bad.ts")
+        assert diags and diags[0][0] == "error", diags
+    finally:
+        svc.stop()

--- a/tests/test_lspclient.py
+++ b/tests/test_lspclient.py
@@ -1,0 +1,205 @@
+"""Protocol mechanics of chad's generic LSP client (lspclient.py), against a
+scripted fake server subprocess — real pipes, real Content-Length frames, no
+language server install. This is the layer that had NEVER been exercised end to
+end while solidlsp owned it (test_lsp.py mocked the package absent).
+
+Covered: framing + request/response correlation, initialize handshake,
+server→client requests answered (a server blocked on workspace/configuration
+looks exactly like a hang), logMessage capture (readiness rules grep it),
+publishDiagnostics generations (wait for OUR edit's analysis, not a stale set),
+didOpen/didChange versioning with the unchanged-content skip, result-shape
+normalization (Location vs Location[] vs LocationLink[], hover content shapes),
+request timeout, and shutdown.
+"""
+
+import os
+import sys
+
+import pytest
+
+from chad.lspclient import LspClient, path_to_uri, uri_to_path
+
+# A minimal LSP server: enough of the protocol to exercise every client seam.
+FAKE_SERVER = r"""
+import json, sys
+
+def send(payload):
+    body = json.dumps(payload).encode()
+    sys.stdout.buffer.write(b"Content-Length: %d\r\n\r\n" % len(body) + body)
+    sys.stdout.buffer.flush()
+
+def notify(method, params):
+    send({"jsonrpc": "2.0", "method": method, "params": params})
+
+opens = {}
+while True:
+    line = sys.stdin.buffer.readline()
+    if not line:
+        break
+    if not line.lower().startswith(b"content-length:"):
+        continue
+    n = int(line.split(b":", 1)[1])
+    sys.stdin.buffer.readline()                 # the blank line
+    msg = json.loads(sys.stdin.buffer.read(n))
+    m, rid = msg.get("method"), msg.get("id")
+    p = msg.get("params") or {}
+    if m == "initialize":
+        send({"jsonrpc": "2.0", "id": rid, "result": {"capabilities": {}}})
+        notify("window/logMessage", {"type": 3, "message": "Found 3 source files"})
+        send({"jsonrpc": "2.0", "id": 999, "method": "workspace/configuration",
+              "params": {"items": [{"section": "x"}, {"section": "y"}]}})
+    elif rid == 999 and m is None:              # the client's configuration answer
+        assert msg["result"] == [None, None], msg
+        notify("window/logMessage", {"type": 3, "message": "config-answered"})
+    elif m in ("textDocument/didOpen", "textDocument/didChange"):
+        td = p["textDocument"]
+        opens[td["uri"]] = opens.get(td["uri"], 0) + 1
+        notify("textDocument/publishDiagnostics", {
+            "uri": td["uri"],
+            "diagnostics": [{"range": {"start": {"line": 0, "character": 0},
+                                       "end": {"line": 0, "character": 1}},
+                            "severity": 1,
+                            "message": "boom v%d" % td.get("version", 0)}]})
+    elif m == "textDocument/references":
+        send({"jsonrpc": "2.0", "id": rid, "result": [
+            {"uri": "file:///tmp/other.py",
+             "range": {"start": {"line": 9, "character": 2},
+                       "end": {"line": 9, "character": 8}}}]})
+    elif m == "textDocument/definition":        # single Location, NOT an array
+        send({"jsonrpc": "2.0", "id": rid, "result":
+              {"uri": p["textDocument"]["uri"],
+               "range": {"start": {"line": 4, "character": 0},
+                         "end": {"line": 4, "character": 3}}}})
+    elif m == "textDocument/hover":
+        send({"jsonrpc": "2.0", "id": rid, "result":
+              {"contents": {"kind": "markdown", "value": "(function) helper"}}})
+    elif m == "textDocument/diagnostic":
+        send({"jsonrpc": "2.0", "id": rid, "result":
+              {"kind": "full", "items": [{"range": {"start": {"line": 2, "character": 0},
+                                                    "end": {"line": 2, "character": 1}},
+                                          "severity": 2, "message": "pulled"}]}})
+    elif m == "test/error":
+        send({"jsonrpc": "2.0", "id": rid, "error": {"code": -32601,
+                                                     "message": "nope"}})
+    elif m == "test/never":
+        pass                                    # exercise the client timeout
+    elif m == "shutdown":
+        send({"jsonrpc": "2.0", "id": rid, "result": None})
+    elif m == "exit":
+        sys.exit(0)
+"""
+
+
+@pytest.fixture
+def client(tmp_path):
+    cli = LspClient([sys.executable, "-u", "-c", FAKE_SERVER], str(tmp_path))
+    yield cli
+    cli.shutdown()
+
+
+def test_uri_round_trip(tmp_path):
+    p = str(tmp_path / "dir with space" / "f.py")
+    assert uri_to_path(path_to_uri(p)) == p
+
+
+def test_initialize_and_server_requests(client):
+    result = client.initialize()
+    assert result == {"capabilities": {}}
+    # readiness grep sees past AND future log lines
+    assert client.wait_log(r"Found \d+ source files", timeout=5.0) is True
+    # the server->client workspace/configuration request was answered [null]*items
+    # (the fake acks by logging; an unanswered request would log nothing)
+    assert client.wait_log("config-answered", timeout=5.0) is True
+    assert client.wait_log("never-logged", timeout=0.1) is False
+
+
+def test_references_definition_hover(client, tmp_path):
+    client.initialize()
+    f = str(tmp_path / "f.py")
+    open(f, "w").write("x = 1\n")
+    client.sync_doc(f, "python")
+    assert client.references(f, 0, 0) == [("/tmp/other.py", 10, 3)]
+    assert client.definition(f, 0, 0) == [(f, 5)]  # single-Location normalization
+    assert client.hover(f, 0, 0) == "(function) helper"
+
+
+def test_diagnostic_generations_and_sync_skip(client, tmp_path):
+    client.initialize()
+    f = str(tmp_path / "g.py")
+    open(f, "w").write("y = 2\n")
+    gen0 = client.diag_generation(f)
+    client.sync_doc(f, "python")                       # didOpen v1 -> publish
+    diags = client.wait_diagnostics(f, gen0, timeout=5.0)
+    assert diags and diags[0]["message"] == "boom v1"
+
+    # unchanged content: NO didChange goes out, so no new publish arrives
+    gen1 = client.diag_generation(f)
+    client.sync_doc(f, "python")
+    assert client.wait_diagnostics(f, gen1, timeout=0.3) is None
+
+    # changed content: didChange v2 -> a NEW publish (generation advances)
+    open(f, "w").write("y = 3\n")
+    client.sync_doc(f, "python")
+    diags = client.wait_diagnostics(f, gen1, timeout=5.0)
+    assert diags and diags[0]["message"] == "boom v2"
+
+
+def test_pull_diagnostics(client, tmp_path):
+    client.initialize()
+    f = str(tmp_path / "p.py")
+    open(f, "w").write("z = 1\n")
+    items = client.pull_diagnostics(f)
+    assert items and items[0]["message"] == "pulled"
+
+
+def test_error_and_timeout(client):
+    client.initialize()
+    from chad.lspclient import LspError
+    with pytest.raises(LspError, match="nope"):
+        client.request("test/error")
+    with pytest.raises(TimeoutError):
+        client.request("test/never", timeout=0.2)
+    # the client survives both and still answers
+    assert client.request("shutdown") is None
+
+
+def test_shutdown_reaps_process(client):
+    client.initialize()
+    assert client.alive() is True
+    client.shutdown()
+    assert client.alive() is False
+
+
+def test_dead_server_fails_pending(tmp_path):
+    cli = LspClient([sys.executable, "-c", "import sys; sys.stdin.read(40)"],
+                    str(tmp_path))
+    # server never answers and then exits: pending requests fail, not hang forever
+    with pytest.raises((TimeoutError, Exception)):
+        cli.request("initialize", timeout=3.0)
+    cli.shutdown()
+    assert not cli.alive()
+
+
+def test_open_docs_track_versions(client, tmp_path):
+    client.initialize()
+    f = str(tmp_path / "v.py")
+    open(f, "w").write("a = 1\n")
+    uri = client.sync_doc(f, "python")
+    assert client._open_docs[uri][0] == 1
+    client.sync_doc(f, "python", text="a = 2\n")
+    assert client._open_docs[uri][0] == 2
+    client.sync_doc(f, "python", text="a = 2\n")   # identical: version unchanged
+    assert client._open_docs[uri][0] == 2
+
+
+def test_ignores_path_separators_in_messages(client, tmp_path):
+    """Frames containing multibyte text survive length-based framing."""
+    client.initialize()
+    f = str(tmp_path / "unicode.py")
+    open(f, "w").write("s = 'héllo — ünïcode'\n")
+    client.sync_doc(f, "python")
+    assert client.wait_diagnostics(f, 0, timeout=5.0) is not None
+
+
+def test_fake_server_is_a_real_subprocess(client):
+    assert client.pid and client.pid != os.getpid()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -19,7 +19,7 @@ import time
 
 import pytest
 import uvicorn
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from mcp.types import ToolAnnotations
 
 from chad import mcp, render, tools, validate
@@ -228,6 +228,31 @@ def test_readonly_hint_skips_confirm(project):
     assert tools.is_mutating("mcp__demo__echo") is False        # readOnlyHint: true
     assert tools.is_mutating("mcp__demo__write_note") is True   # default: mutating
     assert tools.is_mutating("bash") is True                    # builtin unaffected
+
+
+# ---------------------------------------------------------------------------
+# mcp 2.x silent-rename pins. Two 1.x -> 2.x attribute renames fail SILENTLY
+# through getattr defaults: code reading the OLD name would not crash, it would
+# just misbehave (every read-only tool demands confirmation; tool-reported errors
+# stop being flagged). Each gets a unit pin that FAILS on the 1.x spelling.
+# ---------------------------------------------------------------------------
+
+def test_is_mutating_reads_snake_case_read_only_hint():
+    """getattr(ann, "readOnlyHint") on a 2.x model returns None -> _is_mutating
+    would classify EVERY read-only tool as mutating. This test fails then."""
+    from mcp.types import Tool
+    t = Tool.model_validate({"name": "x", "inputSchema": {"type": "object"},
+                             "annotations": {"readOnlyHint": True}})  # wire: camelCase
+    assert mcp._is_mutating(t) is False
+
+
+def test_render_result_reads_snake_case_is_error():
+    """getattr(res, "isError", False) on a 2.x model returns False -> tool-reported
+    errors would silently stop being prefixed. This test fails then."""
+    from mcp.types import CallToolResult
+    res = CallToolResult.model_validate(
+        {"content": [{"type": "text", "text": "kaboom"}], "isError": True})
+    assert mcp._render_result(res).startswith("[tool reported an error]")
 
 
 # ---------------------------------------------------------------------------
@@ -489,10 +514,10 @@ def test_midsession_crash_degrades(project):
 # HTTP transport (Streamable HTTP) — a real in-process MCP server on loopback
 # ---------------------------------------------------------------------------
 #
-# The SDK's `streamablehttp_client` drives a true end-to-end HTTP transport against a
-# FastMCP server (built with the SDK's server side) run by uvicorn in a background
-# thread on an ephemeral port. This exercises the same public seam as the stdio tests,
-# proving the transport swap is behavior-preserving across both transports.
+# The SDK's `streamable_http_client` (fed by chad's own `create_mcp_http_client`)
+# drives a true end-to-end HTTP transport against an MCPServer app (the SDK's server
+# side) run by uvicorn in a background thread on an ephemeral port. This exercises the
+# same public seam as the stdio tests, proving the transport is behavior-preserving.
 
 def _free_port():
     s = socket.socket()
@@ -520,9 +545,9 @@ class _CaptureAuth:
 def _build_http_app(holder):
     """A Streamable HTTP MCP app exposing one read-only tool (`ping`, readOnlyHint),
     one mutating tool (`do_write`), and one that always errors (`boom`)."""
-    server = FastMCP("httpdemo")
+    server = MCPServer("httpdemo")
 
-    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @server.tool(annotations=ToolAnnotations(read_only_hint=True))
     def ping(message: str) -> str:
         """Echo back the message (read-only)."""
         return "pong:" + message

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -309,6 +309,51 @@ def test_disabled_server_skipped(tmp_path, monkeypatch):
     mcp.reset_session()
 
 
+def test_unusable_sdk_degrades_gracefully(tmp_path, monkeypatch):
+    """An `mcp` SDK whose symbols chad can't import costs the operator their MCP tools
+    and a warning — never the agent. The SDK import is guarded (chad.mcp is imported
+    unconditionally when an Agent is built, so an ImportError there is an unskippable
+    traceback on startup); this covers the resulting no-SDK state."""
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setattr(os.path, "expanduser",
+                        lambda p: str(home) if p == "~" or p.startswith("~/") else p)
+    (tmp_path / ".mcp.json").write_text(json.dumps(
+        {"mcpServers": {"demo": {"command": "python", "args": ["-c", "pass"]}}}))
+    monkeypatch.chdir(tmp_path)
+    mcp._set_trusted(str(tmp_path))
+    monkeypatch.setattr(mcp, "_SDK_ERROR", "ImportError: cannot import name 'x'")
+    mcp.reset_session()
+    assert mcp.schemas() == []                          # nothing exposed to the model
+    assert mcp.service().clients == []                  # nothing connected
+    assert any("MCP disabled" in w for w in mcp.service().warnings)
+    assert any("MCP disabled" in ln for ln in mcp.summary_lines())
+    mcp.reset_session()
+
+
+def test_unusable_sdk_silent_without_servers(tmp_path, monkeypatch):
+    """No servers configured: nothing to warn about, so the broken SDK is not mentioned
+    — an operator who never used MCP sees no new noise."""
+    home = tmp_path / "home"; home.mkdir()
+    monkeypatch.setattr(os.path, "expanduser",
+                        lambda p: str(home) if p == "~" or p.startswith("~/") else p)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mcp, "_SDK_ERROR", "ImportError: cannot import name 'x'")
+    mcp.reset_session()
+    assert mcp.service().warnings == []
+    assert "no MCP servers configured" in mcp.summary_lines()[0]
+    mcp.reset_session()
+
+
+def test_oauth_disabled_when_sdk_unusable(monkeypatch):
+    """The OAuth symbols are guarded the same way; an unusable SDK reads as flag-off, so
+    every caller takes its existing "OAuth unavailable" path instead of raising."""
+    from chad import mcp_oauth
+    monkeypatch.setenv("CHAD_MCP_OAUTH", "1")
+    assert mcp_oauth.oauth_enabled() is True
+    monkeypatch.setattr(mcp_oauth, "_SDK_ERROR", "ImportError: cannot import name 'x'")
+    assert mcp_oauth.oauth_enabled() is False
+
+
 def test_bad_command_degrades_gracefully(tmp_path, monkeypatch):
     home = tmp_path / "home"; home.mkdir()
     monkeypatch.setattr(os.path, "expanduser",

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -33,7 +33,7 @@ import urllib.request
 import anyio
 import pytest
 import uvicorn
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from mcp.types import ToolAnnotations
 
@@ -232,9 +232,9 @@ def _free_port():
 
 
 def _build_app():
-    server = FastMCP("oauthdemo")
+    server = MCPServer("oauthdemo")
 
-    @server.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @server.tool(annotations=ToolAnnotations(read_only_hint=True))
     def ping(message: str) -> str:
         """Echo back the message (read-only)."""
         return "pong:" + message

--- a/tests/test_repomap_polyglot.py
+++ b/tests/test_repomap_polyglot.py
@@ -1,0 +1,108 @@
+"""Polyglot coverage for the tree-sitter substrate (tests/fixtures/polyglot).
+
+The repo map claims language-agnostic symbol intelligence via the language pack's
+grammars, yet until this file every repo-map fixture was Python. Each fixture
+language carries the same three deliberate cases:
+
+  * a class method whose bare name collides with a free function elsewhere
+    (`Engine.process` vs `process`) — the qualified-path case,
+  * a cross-file reference through an import (`helper` defined in lib, called in
+    app) — the precision case,
+  * the same name defined in two files — the disambiguation case.
+
+First measurement (2026-07-29) found the pack's tags queries broken or missing for
+4 of 12 languages — typescript/tsx (no query at all), php (query names a node type
+the current grammar renamed), c (no reference captures; header prototypes tagged
+as definitions), cpp (out-of-class `Engine::process` invisible) — fixed by chad's
+`repomap._TAGS_OVERRIDE`. This test pins all 12 so a language-pack bump that
+breaks a grammar's tags surfaces here, not in an agent run.
+
+No model, no language server, no network; runs in the fast gate.
+"""
+
+import os
+
+import pytest
+
+from chad.repomap import RepoMap
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures", "polyglot")
+
+# lang -> (helper fn, colliding name, caller fn, container symbol, lib file, app file)
+LANGS = {
+    "python": ("helper", "process", "run", "Engine", "lib.py", "app.py"),
+    "typescript": ("helper", "process", "run", "Engine", "lib.ts", "app.ts"),
+    "javascript": ("helper", "process", "run", "Engine", "lib.js", "app.js"),
+    "go": ("Helper", "Process", "Run", "Engine", "lib.go", "app.go"),
+    "rust": ("helper", "process", "run", "Engine", "lib.rs", "app.rs"),
+    "java": ("helper", "process", "run", "Engine", "Engine.java", "App.java"),
+    "ruby": ("helper", "process", "run", "Engine", "lib.rb", "app.rb"),
+    "csharp": ("Helper", "Process", "Run", "Engine", "Lib.cs", "App.cs"),
+    "php": ("helper", "process", "run", "Engine", "lib.php", "app.php"),
+    "kotlin": ("helper", "process", "run", "Engine", "Lib.kt", "App.kt"),
+    "c": ("helper", "process", "run", "engine_process", "lib.c", "app.c"),
+    "cpp": ("helper", "process", "run", "Engine", "lib.cpp", "app.cpp"),
+}
+
+
+def _map_for(lang):
+    rm = RepoMap(os.path.join(FIXTURES, lang))
+    rm._disk_checked = True  # hermetic: never read/write the user's real tags cache
+    return rm
+
+
+@pytest.mark.parametrize("lang", sorted(LANGS))
+def test_definitions_extracted(lang):
+    """Every fixture language yields its definitions: the container symbol, the
+    method/collider in lib, and the free function + caller in app."""
+    helper, process, run, container, lib, app = LANGS[lang]
+    rm = _map_for(lang)
+    by_file = {}
+    for f in rm._code_files():
+        defs, _ = rm._extract(f)
+        by_file[rm._rel(f)] = {d.name for d in defs}
+    everywhere = set().union(*by_file.values())
+    assert container in everywhere, by_file  # cpp: class in lib.hpp, methods in lib.cpp
+    assert process in by_file[lib], by_file
+    assert process in by_file[app], by_file
+    assert run in by_file[app], by_file
+
+
+@pytest.mark.parametrize("lang", sorted(LANGS))
+def test_find_and_view_symbol(lang):
+    helper, _process, run, _container, lib, app = LANGS[lang]
+    rm = _map_for(lang)
+    fs = rm.find_symbol(helper)
+    assert lib in fs, fs
+    vs = rm.view_symbol(run)
+    assert vs.startswith(f"{app}:"), vs
+    assert process_call_present(vs, lang), vs
+
+
+def process_call_present(view, lang):
+    """The viewed `run` body must contain the call into Engine's method — the span
+    is real code, not a header-only stub."""
+    needle = {"go": "e.Process(", "csharp": ".Process(", "c": "engine_process(",
+              "php": "->process("}.get(lang, ".process(")
+    return needle in view
+
+
+@pytest.mark.parametrize("lang", sorted(LANGS))
+def test_cross_file_refs(lang):
+    """`helper` is defined in lib and called in app: find_refs must return the
+    cross-file hit (name-match honesty label is fine; missing the hit is not)."""
+    helper, _process, _run, _container, _lib, app = LANGS[lang]
+    rm = _map_for(lang)
+    fr = rm.find_refs(helper)
+    assert app in fr, fr
+
+
+@pytest.mark.parametrize("lang", sorted(LANGS))
+def test_same_name_two_files_disambiguates(lang):
+    """The colliding name is defined in two files; a bare view_symbol must return
+    the disambiguation listing naming both, not silently pick one."""
+    _helper, process, _run, _container, lib, app = LANGS[lang]
+    rm = _map_for(lang)
+    out = rm.view_symbol(process)
+    assert "pass path= to disambiguate" in out, out
+    assert lib in out and app in out, out

--- a/tests/test_repomap_polyglot.py
+++ b/tests/test_repomap_polyglot.py
@@ -14,8 +14,10 @@ First measurement (2026-07-29) found the pack's tags queries broken or missing f
 4 of 12 languages — typescript/tsx (no query at all), php (query names a node type
 the current grammar renamed), c (no reference captures; header prototypes tagged
 as definitions), cpp (out-of-class `Engine::process` invisible) — fixed by chad's
-`repomap._TAGS_OVERRIDE`. This test pins all 12 so a language-pack bump that
-breaks a grammar's tags surfaces here, not in an agent run.
+`repomap._TAGS_OVERRIDE`, which also adds bash outright (the pack ships no bash
+query; 89 of 91 terminal-bench-2.1 tasks contain shell). This test pins all 13
+languages so a language-pack bump that breaks a grammar's tags surfaces here, not
+in an agent run.
 
 No model, no language server, no network; runs in the fast gate.
 """
@@ -42,6 +44,7 @@ LANGS = {
     "kotlin": ("helper", "process", "run", "Engine", "Lib.kt", "App.kt"),
     "c": ("helper", "process", "run", "engine_process", "lib.c", "app.c"),
     "cpp": ("helper", "process", "run", "Engine", "lib.cpp", "app.cpp"),
+    "bash": ("helper", "process", "run", "engine_process", "lib.sh", "app.sh"),
 }
 
 
@@ -83,7 +86,7 @@ def process_call_present(view, lang):
     """The viewed `run` body must contain the call into Engine's method — the span
     is real code, not a header-only stub."""
     needle = {"go": "e.Process(", "csharp": ".Process(", "c": "engine_process(",
-              "php": "->process("}.get(lang, ".process(")
+              "php": "->process(", "bash": "engine_process "}.get(lang, ".process(")
     return needle in view
 
 

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -1,13 +1,12 @@
-"""Characterization tests for symbols.py — the jedi-backed symbol EDITOR that writes
-to source files. Previously ZERO direct coverage. test_edit.py is the text-edit
-analogue; this is the symbol-edit one.
+"""Characterization tests for symbols.py — the symbol EDITOR that writes to source
+files. test_edit.py is the text-edit analogue; this is the symbol-edit one.
 
-A bug in `_span`/`_apply` silently edits the wrong line range (clobbering an adjacent
-symbol); a bug in `_locate_one`/`_matches` targets a free function when a method was
-meant. These pin: replace lands on exactly the named span, qualified `Class/method`
-targeting works, insert keeps the file parseable, and the not-found / empty-content
-guards leave the file untouched. jedi is a hard dependency so these always run — no
-model gate.
+A bug in `_locate_one`/`_apply` silently edits the wrong line range (clobbering an
+adjacent symbol) or targets a free function when a method was meant. These pin:
+replace lands on exactly the named span, qualified `Class/method` targeting works
+(in TWO languages — the backend is one tree-sitter path for all of them, so an
+asymmetry here is a regression), insert keeps the file parseable, and the
+not-found / empty-content guards leave the file untouched. No model gate.
 
 Run: `uv run python tests/test_symbols.py`
 """
@@ -79,6 +78,43 @@ def test_qualified_name_targets_method(tmp_path):
     check("still parses after method replace", _parses(after, fp))
 
 
+def test_qualified_method_vs_free_function(tmp_path):
+    """A method and a free function share a bare name: the qualified path must hit
+    the method, the bare name must disambiguate — in both fixture languages."""
+    svc = _tree(tmp_path, {
+        "shape.py": ("class Shape:\n"
+                     "    def area(self):\n"
+                     "        return 1\n"
+                     "\n\n"
+                     "def area():\n"
+                     "    return 2\n"),
+        "shape.js": ("class Shape {\n"
+                     "  area() {\n"
+                     "    return 1;\n"
+                     "  }\n"
+                     "}\n"
+                     "\n"
+                     "function area() {\n"
+                     "  return 2;\n"
+                     "}\n"),
+    })
+    for fn, comment in (("shape.py", "python"), ("shape.js", "javascript")):
+        fp = os.path.join(str(tmp_path), fn)
+        res = svc.replace_symbol(
+            "Shape/area",
+            "  def area(self):\n        return 11" if fn.endswith(".py")
+            else "  area() {\n    return 11;\n  }",
+            path=fp)
+        check(f"{comment}: qualified replace lands", res.startswith("[replaced"), res)
+        check(f"{comment}: label is Shape.area", "Shape.area" in res, res)
+        after = open(fp).read()
+        check(f"{comment}: free area() untouched", "return 2" in after, after)
+        check(f"{comment}: method rewritten", "11" in after, after)
+        # the bare name stays ambiguous: no silent pick between method and function
+        bare = svc.replace_symbol("area", "x", path=None)
+        check(f"{comment}: bare name disambiguates", "disambiguate" in bare, bare)
+
+
 def test_insert_after_places_and_parses(tmp_path):
     svc, fp = _fixture(tmp_path)
     res = svc.insert_symbol("alpha", "def inserted():\n    return 0",
@@ -101,6 +137,15 @@ def test_not_found_leaves_file_untouched(tmp_path):
     check("file unchanged on not-found", open(fp).read() == SRC)
 
 
+def test_qualified_never_falls_back_to_bare(tmp_path):
+    """A qualified path whose container doesn't exist must be a miss, not a silent
+    resolve to the bare last segment (editing the wrong symbol is corruption)."""
+    svc, fp = _fixture(tmp_path)
+    res = svc.replace_symbol("NoSuchClass/alpha", "def alpha():\n    return 0", path=fp)
+    check("wrong qualifier is a miss", "symbol not found" in res, res)
+    check("file unchanged on qualified miss", open(fp).read() == SRC)
+
+
 def test_empty_content_refused(tmp_path):
     svc, fp = _fixture(tmp_path)
     res = svc.replace_symbol("alpha", "   ", path=fp)
@@ -116,16 +161,6 @@ def _parses(src, fp):
         return False
 
 
-# ---------------------------------------------------------------------------
-# Locate-path guardrails (profiling pass on the 11k-file pytorch clone). The
-# pathologies these anchor, all measured before the fix: the substring prefilter
-# ("main" in text) matched thousands of files ("domain", __main__ guards, comments)
-# and every false candidate cost a full jedi parse — 130s for _find_defs("main");
-# a name defined in hundreds of files was jedi-parsed in each one just to say
-# "ambiguous" (60s for 'forward'); disambiguation listings were unbounded (205
-# lines of 'main' straight into prefill).
-# ---------------------------------------------------------------------------
-
 def _tree(tmp_path, spec):
     """Write {relpath: content} under tmp_path and return a SymbolService on it."""
     for rel, content in spec.items():
@@ -135,28 +170,19 @@ def _tree(tmp_path, spec):
     return SymbolService(str(tmp_path))
 
 
-def test_prefilter_wants_definition_shape(tmp_path):
-    svc = _tree(tmp_path, {
-        "defines.py": "def main():\n    return 1\n",
-        "calls.py": "from defines import main\nmain()\n",
-        "guard.py": "if __name__ == '__main__':\n    pass\n",
-        "substr.py": "domain = 'remains'\n",
-    })
-    cands = [os.path.basename(c) for c in svc._candidate_files("main")]
-    check("only the def site is a candidate", cands == ["defines.py"], cands)
-
-
-def test_mass_definer_bails_by_file(tmp_path):
+def test_mass_definer_disambiguates_capped(tmp_path):
+    """A name defined in dozens of files yields a capped disambiguation listing
+    (unbounded listings measured 205 lines of 'main' straight into prefill), and
+    path= still resolves precisely."""
     from chad import symbols as symmod
-    n = symmod._MAX_DEF_FILES + symmod._DISAMBIG_MAX_LINES + 3
+    n = symmod._DISAMBIG_MAX_LINES + 19
     svc = _tree(tmp_path, {f"m{i:03d}.py": "def forward(x):\n    return x\n"
                            for i in range(n)})
-    hit, err = svc._locate_one("forward", None)
-    check("mass definer returns no hit", hit is None, err)
-    check("by-file disambig names the count", f"defined in {n} files" in err, err)
-    listed = [ln for ln in err.splitlines() if ln.startswith("  m")]
-    check("listing capped", len(listed) == symmod._DISAMBIG_MAX_LINES, err)
-    check("overflow announced", "more)" in err.splitlines()[-1], err)
+    res = svc.replace_symbol("forward", "def forward(x):\n    return x + 1")
+    check("mass definer disambiguates", f"{n} symbols named 'forward'" in res, res)
+    listed = [ln for ln in res.splitlines() if ln.startswith("  m")]
+    check("listing capped", len(listed) == symmod._DISAMBIG_MAX_LINES, res)
+    check("overflow announced", "more)" in res.splitlines()[-1], res)
     res = svc.replace_symbol("forward", "def forward(x):\n    return x + 1",
                              path=os.path.join(str(tmp_path), "m000.py"))
     check("path= still resolves precisely", res.startswith("[replaced"), res)
@@ -167,15 +193,15 @@ def test_new_file_visible_despite_walk_memo(tmp_path):
     check("warm-up locate works", svc._locate_one("alpha", None)[0] is not None)
     with open(os.path.join(str(tmp_path), "fresh.py"), "w") as f:
         f.write("def beta():\n    pass\n")
-    svc._py_files_at -= 2.0  # age the memo past the retry guard, not past the TTL
+    svc._repomap()._files_at -= 2.0  # age the memo past the re-walk guard
     hit, err = svc._locate_one("beta", None)
     check("file created after the cached walk is found", hit is not None, err)
 
 
 # ---------------------------------------------------------------------------
-# Multi-language editing: non-Python files resolve through the tree-sitter repo
-# map's definition spans (the same ones view_symbol shows). Python behavior is
-# pinned above and must be unchanged. Skips cleanly if the grammar can't load.
+# Multi-language editing: every language resolves through the tree-sitter repo
+# map's definition spans (the same ones view_symbol shows). Skips cleanly if the
+# grammar can't load.
 # ---------------------------------------------------------------------------
 
 JS = """function greet(name) {
@@ -189,7 +215,8 @@ function farewell(name) {
 
 
 def _js_available(svc):
-    return bool(svc._ts_locate("greet", None))
+    hit, _err = svc._locate_one("greet", None)
+    return hit is not None
 
 
 def test_replace_symbol_javascript(tmp_path):
@@ -209,13 +236,15 @@ def test_replace_symbol_javascript(tmp_path):
           after2.index("function farewell") < after2.index("function extra"), after2)
 
 
-def test_python_still_wins_name_collisions(tmp_path):
-    """A name defined in both a .py and a non-py file must keep resolving to the
-    Python definition (the pre-generalization behavior)."""
+def test_cross_language_collision_disambiguates(tmp_path):
+    """A name defined in both a .py and a .js file is ambiguous and says so —
+    the old backend silently preferred Python, which is exactly the per-language
+    asymmetry the unified backend removed."""
     svc = _tree(tmp_path, {"m.py": "def greet():\n    return 1\n", "app.js": JS})
     hit, err = svc._locate_one("greet", None)
-    check("collision resolves", hit is not None, err)
-    check("collision resolves to python", hit[2].endswith("m.py"), hit)
+    check("collision returns no silent hit", hit is None, hit)
+    check("collision disambiguates across languages",
+          err and "m.py" in err and "app.js" in err, err)
 
 
 def test_non_python_not_found_is_clean(tmp_path):
@@ -228,17 +257,19 @@ def test_reedit_uses_fresh_parse(tmp_path):
     svc = _tree(tmp_path, {"mod.py": "def f():\n    return 1\n"})
     res = svc.replace_symbol("f", "def f():\n    return 2\ndef g():\n    return 3")
     check("first replace lands", res.startswith("[replaced"), res)
-    # g() only exists post-edit; finding it proves the (path, mtime) cache evicted
+    # g() only exists post-edit; finding it proves the mtime cache evicted
     hit, err = svc._locate_one("g", None)
     check("post-edit parse is fresh", hit is not None, err)
 
 
 if __name__ == "__main__":
     for fn in (test_replace_lands_on_one_symbol, test_qualified_name_targets_method,
+               test_qualified_method_vs_free_function,
                test_insert_after_places_and_parses, test_not_found_leaves_file_untouched,
-               test_empty_content_refused, test_prefilter_wants_definition_shape,
-               test_mass_definer_bails_by_file, test_new_file_visible_despite_walk_memo,
-               test_replace_symbol_javascript, test_python_still_wins_name_collisions,
+               test_qualified_never_falls_back_to_bare, test_empty_content_refused,
+               test_mass_definer_disambiguates_capped,
+               test_new_file_visible_despite_walk_memo,
+               test_replace_symbol_javascript, test_cross_language_collision_disambiguates,
                test_non_python_not_found_is_clean, test_reedit_uses_fresh_parse):
         with tempfile.TemporaryDirectory() as d:
             fn(d)

--- a/uv.lock
+++ b/uv.lock
@@ -31,24 +31,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anthropic"
-version = "0.59.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/52daff015f5a1f24eec891b3041f5f816712fea8b5113dc76638bcbc23d8/anthropic-0.59.0.tar.gz", hash = "sha256:d710d1ef0547ebbb64b03f219e44ba078e83fc83752b96a9b22e9726b523fd8f", size = 425679, upload-time = "2025-07-23T16:23:16.901Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/b1/03f680393eac04afd8f2be44ee0e39e033c40faf43dbc1c11764b07a2687/anthropic-0.59.0-py3-none-any.whl", hash = "sha256:cbc8b3dccef66ad6435c4fa1d317e5ebb092399a4b88b33a09dc4bf3944c3183", size = 293057, upload-time = "2025-07-23T16:23:14.934Z" },
-]
-
-[[package]]
 name = "anyio"
 version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -68,50 +50,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
-]
-
-[[package]]
-name = "beautifulsoup4"
-version = "4.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "soupsieve" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/77/e9/df2358efd7659577435e2177bfa69cba6c33216681af51a707193dec162a/beautifulsoup4-4.14.2.tar.gz", hash = "sha256:2a98ab9f944a11acee9cc848508ec28d9228abfd522ef0fad6a02a72e0ded69e", size = 625822, upload-time = "2025-09-29T10:05:42.613Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/fe/3aed5d0be4d404d12d36ab97e2f1791424d9ca39c2f754a6285d59a3b01d/beautifulsoup4-4.14.2-py3-none-any.whl", hash = "sha256:5ef6fa3a8cbece8488d66985560f97ed091e22bbc4e9c2338508a9d5de6d4515", size = 106392, upload-time = "2025-09-29T10:05:43.771Z" },
-]
-
-[[package]]
-name = "blinker"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
-]
-
-[[package]]
-name = "bottle"
-version = "0.13.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7a/71/cca6167c06d00c81375fd668719df245864076d284f7cb46a694cbeb5454/bottle-0.13.4.tar.gz", hash = "sha256:787e78327e12b227938de02248333d788cfe45987edca735f8f88e03472c3f47", size = 98717, upload-time = "2025-06-15T10:08:59.439Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/f6/b55ec74cfe68c6584163faa311503c20b0da4c09883a41e8e00d6726c954/bottle-0.13.4-py2.py3-none-any.whl", hash = "sha256:045684fbd2764eac9cdeb824861d1551d113e8b683d8d26e296898d3dd99a12e", size = 103807, upload-time = "2025-06-15T10:08:57.691Z" },
-]
-
-[[package]]
-name = "cattrs"
-version = "26.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
 ]
 
 [[package]]
@@ -199,7 +137,6 @@ version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },
-    { name = "jedi" },
     { name = "jinja2" },
     { name = "mcp" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
@@ -217,9 +154,6 @@ dependencies = [
 highlight = [
     { name = "pygments" },
 ]
-lsp = [
-    { name = "serena-agent" },
-]
 speech = [
     { name = "sounddevice" },
 ]
@@ -235,22 +169,20 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "huggingface-hub", specifier = ">=1.22.0" },
-    { name = "jedi", specifier = ">=0.19.2" },
     { name = "jinja2", specifier = ">=3.1" },
-    { name = "mcp", specifier = ">=1.27,<2" },
+    { name = "mcp", specifier = ">=2,<3" },
     { name = "mlx", marker = "sys_platform == 'darwin'", specifier = ">=0.32.0,<0.33" },
     { name = "mlx-lm", marker = "sys_platform == 'darwin'", specifier = ">=0.31.3,<0.32" },
     { name = "numpy", specifier = ">=1.26,<3" },
     { name = "prompt-toolkit", specifier = ">=3.0.43" },
     { name = "pygments", marker = "extra == 'highlight'", specifier = ">=2.17" },
     { name = "rustworkx", specifier = ">=0.15" },
-    { name = "serena-agent", marker = "extra == 'lsp'", specifier = ">=1.5" },
     { name = "sounddevice", marker = "extra == 'speech'", specifier = ">=0.5" },
     { name = "transformers", specifier = ">=5.0,<5.13" },
     { name = "tree-sitter", specifier = ">=0.26.0" },
     { name = "tree-sitter-language-pack", specifier = ">=1.12.2" },
 ]
-provides-extras = ["highlight", "lsp", "speech"]
+provides-extras = ["highlight", "speech"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -258,95 +190,6 @@ dev = [
     { name = "pytest", specifier = ">=8" },
     { name = "ruff", specifier = ">=0.6" },
     { name = "types-pyyaml", specifier = ">=6" },
-]
-
-[[package]]
-name = "charset-normalizer"
-version = "3.4.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
-    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
-    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
-    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
-    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
-    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
-    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
-    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
-    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
-    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
-    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
-    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
-    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
-    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
-    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
-    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
-    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
-    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
-    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
-    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
-    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
-    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
-    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
-    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
-    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
-    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
-    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -359,18 +202,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
-]
-
-[[package]]
-name = "clr-loader"
-version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/46/7eea92b6aa2d68af78e049cbecec5f757f1aad44ecdecdc16bbad7eead51/clr_loader-0.3.1.tar.gz", hash = "sha256:2e073e9aaf49d1ae2f56ecba27987ad5fb68be4bcd9dd34a5bed8f0e4e128366", size = 86805, upload-time = "2026-04-18T17:49:44.287Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/da/ec1a6e36624000b6df0dd61183c42342ee5814c073315e802cadaad04d2f/clr_loader-0.3.1-py3-none-any.whl", hash = "sha256:cbad189de20d202a7d621956b0fc38049e13c9bf7ca2923441eff725cd121aa1", size = 55730, upload-time = "2026-04-18T17:49:42.99Z" },
 ]
 
 [[package]]
@@ -442,58 +273,12 @@ wheels = [
 ]
 
 [[package]]
-name = "distro"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
-]
-
-[[package]]
-name = "docstring-parser"
-version = "0.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
-]
-
-[[package]]
-name = "dotenv"
-version = "0.9.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dotenv" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/b7/545d2c10c1fc15e48653c91efde329a790f2eecfbbf2bd16003b5db2bab0/dotenv-0.9.9-py2.py3-none-any.whl", hash = "sha256:29cf74a087b31dafdb5a446b6d7e11cbce8ed2741540e2339c69fbef92c94ce9", size = 1892, upload-time = "2025-02-19T22:15:01.647Z" },
-]
-
-[[package]]
 name = "filelock"
 version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
-]
-
-[[package]]
-name = "flask"
-version = "3.1.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "blinker" },
-    { name = "click" },
-    { name = "itsdangerous" },
-    { name = "jinja2" },
-    { name = "markupsafe" },
-    { name = "werkzeug" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
 ]
 
 [[package]]
@@ -560,6 +345,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -575,12 +373,19 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -622,27 +427,6 @@ wheels = [
 ]
 
 [[package]]
-name = "itsdangerous"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
-]
-
-[[package]]
-name = "jedi"
-version = "0.20.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "parso" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
-]
-
-[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -652,101 +436,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
-name = "jiter"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/3f/fae6cc967d120ec89e31c5418a51176d8278b3087fbb384a9176754f353c/jiter-0.16.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:67fddeda1688f0cce2d2ae83ccf8a80f79936f2d2997d6cc2261f82fdb54a4d3", size = 309289, upload-time = "2026-06-29T13:02:52.301Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/e3/97c6c3562c077f6247d6e6ce5c82562500b6316c0d928e97e106b7a1321a/jiter-0.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c90c0f63df322be920eda6ce622e3083d8906ba267f8220fe7873213b8b4430e", size = 315181, upload-time = "2026-06-29T13:02:53.964Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/89/d8d073f8aa2667e46c6c0873f86fe4a512bba4293cc730f626a076211a62/jiter-0.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64c0203212098470032aabcde9356fc168f377aade3e43def61dfe17e92f2037", size = 340939, upload-time = "2026-06-29T13:02:55.412Z" },
-    { url = "https://files.pythonhosted.org/packages/87/c9/db4fda3ed73fb864139305e935e5b8b38a5a24692a5a9dd356c22f1b9c8d/jiter-0.16.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12288303c9844e61e1651d02a9a6f6633e47d39f897d6991d1427161ce6b746e", size = 364932, upload-time = "2026-06-29T13:02:57.28Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/74/52b5e86241057f52ddd7c9a580f90effb51f9d06239f6fc612279b91a838/jiter-0.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cf109d010b4b05a105afb3d43be36a21322d345ad3111e13d15f680afef0e5b", size = 461132, upload-time = "2026-06-29T13:02:58.994Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/87/544a700f7447c1f31c5d7833821a4daa5683165c2d5a094fbf5b5800c3dc/jiter-0.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62c1b7fe1f77925acf5af68b6140b8810fa87dfd4dc0a9c8568ec2fa2a10429c", size = 374857, upload-time = "2026-06-29T13:03:00.455Z" },
-    { url = "https://files.pythonhosted.org/packages/40/cd/0fcc3f7d39183674d5bfa9ec640faaeb506c60be7c8f94625dfba366e37c/jiter-0.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8597d23c87f59294f83bcb6229b9ed1fccee13dbba967b46930d2f1759466fee", size = 347053, upload-time = "2026-06-29T13:03:02.045Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/ae/c7e64e7932ad597fa395b61440b249ada6366716e25c6e08dd2afbd021e6/jiter-0.16.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3126a5dbad56401989ac769aca0cb56005bfb3e2366eea0ca99d1a91c3c1ee03", size = 356153, upload-time = "2026-06-29T13:03:03.706Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/1c/1c719044f14da814e1a060191ab19b96f3e99207bc5b4bfc6d6be34b3f80/jiter-0.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c4b4717bdb35ae456f831a6b08d01880fff399887a6bbc526a583a406e484eea", size = 393956, upload-time = "2026-06-29T13:03:05.165Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/dc/7b2f303a2847207e265503853a2d964a55354cffd62a5f2936c155486798/jiter-0.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:adff21bc78edfe086c15eb495b900306076de378dc2337c132401fc39bd79c91", size = 521081, upload-time = "2026-06-29T13:03:06.886Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/5f/501cf6e1e09caeb420195179ffc6f62aca603f1220ec53fd80d0d70b3e56/jiter-0.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dab907db06fc593645e73109acf4581ba5b548897d28b9348dc41ddc8343b2d3", size = 552085, upload-time = "2026-06-29T13:03:08.339Z" },
-    { url = "https://files.pythonhosted.org/packages/79/54/aa5be86520113b79455c3877f3d1f07a348098df4083ba3688e9537e52dd/jiter-0.16.0-cp311-cp311-win32.whl", hash = "sha256:560b2cf3fb03240cd34f27409a238547488708f05b7c3924f571a60422251ec7", size = 206755, upload-time = "2026-06-29T13:03:09.653Z" },
-    { url = "https://files.pythonhosted.org/packages/64/ec/2feb893eb330bd69b413866f4d5daada33c3962f1c6f270c91ca2d87fdf9/jiter-0.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:e431cfc9caf44c1d5459ff77d4e64cbf85fddb6a35dad836a15c6a9ec23087c1", size = 199155, upload-time = "2026-06-29T13:03:10.979Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/9c/ca040d94415048a3666fc237774df8151c96f8d2b661cbe3b184acc95876/jiter-0.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:2a8e9e39cf083016137aa5cadafe3188adc2ba6ba1fbf1e5d18889ad3e9ad056", size = 194403, upload-time = "2026-06-29T13:03:12.341Z" },
-    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
-    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
-    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
-    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
-    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
-    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
-    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
-    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
-    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
-    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
-    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
-    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
-    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
-    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
-    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
-    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
-    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
-    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
-    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
-    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
-    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
-    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
-    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
-    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
-    { url = "https://files.pythonhosted.org/packages/06/d3/8e278946d43eeca2585b4dd0834a887cd71136329b837f3a16ed86a8b4b0/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:850ccb1d7eedb4200f4014b1c0e8a577de114fc3cd88faad646dcc9bc4bb12ad", size = 304518, upload-time = "2026-06-29T13:05:00.172Z" },
-    { url = "https://files.pythonhosted.org/packages/72/43/28d4ef495028bf0506a413d4db3f4eb3e7288a382e0f065f306a17bbeb5e/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:e34e97bda77eb63242a410243c071e28ac7e0d8c0948c5ee658498690a4b2f2f", size = 310207, upload-time = "2026-06-29T13:05:02.123Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ca/c366b1012da1d640de975d9683acd44e4d150d9068845d0ca2610435253f/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7dc85ea77d4abbae8bad0d3538678aedee75bceec4e2f6c8dfb1c74772e5aa5", size = 342771, upload-time = "2026-06-29T13:05:03.55Z" },
-    { url = "https://files.pythonhosted.org/packages/16/52/50cc4056fc1ae02e7154704e7ecc89df0afb8300222cfe8a52d3f67e4730/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17ca7fae79f6d99cd9a042b75f917eaada7b895cfc7dd2ee3a16089dcaec7a85", size = 346468, upload-time = "2026-06-29T13:05:05.452Z" },
-    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
-    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
-]
-
-[[package]]
-name = "joblib"
-version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/fe/0f5a938c54105553436dbff7a61dc4fed4b1b2c98852f8833beaf4d5968f/joblib-1.5.1.tar.gz", hash = "sha256:f4f86e351f39fe3d0d32a9f2c3d8af1ee4cec285aafcb27003dda5205576b444", size = 330475, upload-time = "2025-05-23T12:04:37.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/4f/1195bbac8e0c2acc5f740661631d8d750dc38d4a32b23ee5df3cde6f4e0d/joblib-1.5.1-py3-none-any.whl", hash = "sha256:4719a31f054c7d766948dcd83e9613686b27114f190f717cec7eaa2084f8a74a", size = 307746, upload-time = "2025-05-23T12:04:35.124Z" },
 ]
 
 [[package]]
@@ -850,19 +539,6 @@ wheels = [
 ]
 
 [[package]]
-name = "lsprotocol"
-version = "2025.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "cattrs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/26/67b84e6ec1402f0e6764ef3d2a0aaf9a79522cc1d37738f4e5bb0b21521a/lsprotocol-2025.0.0.tar.gz", hash = "sha256:e879da2b9301e82cfc3e60d805630487ac2f7ab17492f4f5ba5aaba94fe56c29", size = 74896, upload-time = "2025-06-17T21:30:18.156Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl", hash = "sha256:f9d78f25221f2a60eaa4a96d3b4ffae011b107537facee61d3da3313880995c7", size = 76250, upload-time = "2025-06-17T21:30:19.455Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -950,15 +626,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -968,9 +644,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -1224,12 +913,15 @@ wheels = [
 ]
 
 [[package]]
-name = "overrides"
-version = "7.7.0"
+name = "opentelemetry-api"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", size = 22812, upload-time = "2024-01-27T21:01:33.423Z" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", size = 17832, upload-time = "2024-01-27T21:01:31.393Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -1242,106 +934,12 @@ wheels = [
 ]
 
 [[package]]
-name = "parso"
-version = "0.8.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
-]
-
-[[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
-]
-
-[[package]]
-name = "pillow"
-version = "12.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/c8/0a78b0e02d7ac54bc03e5321c9220da52f0c2ea83b21f7c40e7f3169c502/pillow-12.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:00808c5e14ef63ac5161091d242999076604ff74b883423a11e5d7bbb38bf756", size = 5392415, upload-time = "2026-07-01T11:53:47.162Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/5b/a02d30018abd97ced9f5a6c63d28597694a00d066516b9c1c6de45859fc9/pillow-12.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:37d6d0a00072fd2948eb22bce7e1475f34569d90c87c59f7a2ec59541b77f7a6", size = 4785266, upload-time = "2026-07-01T11:53:49.079Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/98/766667a4be768150a202836acd9fad19c06824ca86c4286d3cf6b274964e/pillow-12.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bcb46e2f9feff8d06323983bd83ed00c201fdcab3d74973e7072a889b3979fcd", size = 6263814, upload-time = "2026-07-01T11:53:51.32Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/2d/ede717bc1144f63886c21fd349bb95860b0d1a21149ff16f2bb362b612b6/pillow-12.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23d27a3e0307ec2244cc51e7287b919aa68d097504ebe19df4e76a98a3eea5bd", size = 6934408, upload-time = "2026-07-01T11:53:53.487Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/48/9c58b685e69d49c31af6c8eb9012055fab7e665785165c84796e2c73ce72/pillow-12.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4f883547d4b7f0495ebe7056b0cc2aea76094e7a4abc8e933540f3271df27d9c", size = 6337160, upload-time = "2026-07-01T11:53:55.457Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/fa/dc2a5c0ba6df93f67c31d34b808b7ce440b40cdbf96f0b81cde1d1e6fa93/pillow-12.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:236ff70b9312fb68943c703aa842ca6a758abfa45ac187a5e7c1452e96ef72b5", size = 7045172, upload-time = "2026-07-01T11:53:57.736Z" },
-    { url = "https://files.pythonhosted.org/packages/86/a5/444817a4d4c4c2417df00513086ca196f388d8f9ef40c2e4ccd1ad1af54b/pillow-12.3.0-cp311-cp311-win32.whl", hash = "sha256:10e41f0fbf1eec8cfd234b8fe17a4caac7c9d0db4c204d3c173a8f9f6ef3232b", size = 6472232, upload-time = "2026-07-01T11:53:59.767Z" },
-    { url = "https://files.pythonhosted.org/packages/63/c6/4bad1b18d132a50b27e1365e1ab163616f7a5bb56d330f66f9d1d9d4f9d4/pillow-12.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:8e95e1385e4998ae9694eeaa4730ba5457ff61185b3a55e2e7bea0880aef452a", size = 7233653, upload-time = "2026-07-01T11:54:02.066Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/16/00f91ab7760dc842f5aad55217e80fc4a7067a0604535249bc8a2d6d9870/pillow-12.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:ebaea975e03d3141d9d3a507df75c9b3ec90fa9d2ffd07567b3a978d9d790b26", size = 2568195, upload-time = "2026-07-01T11:54:04.622Z" },
-    { url = "https://files.pythonhosted.org/packages/37/bf/fb3ebff8ddcb76aac5a01389251bbbb9519922a9b520d8247c1ca864a25d/pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965", size = 5345969, upload-time = "2026-07-01T11:54:06.397Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7", size = 4780323, upload-time = "2026-07-01T11:54:09.351Z" },
-    { url = "https://files.pythonhosted.org/packages/25/27/ac8f99618ffd3dde21db0f4d4b1d2ab00c0880595bfd17df103f7f39fd0c/pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9", size = 6266838, upload-time = "2026-07-01T11:54:11.71Z" },
-    { url = "https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91", size = 6940830, upload-time = "2026-07-01T11:54:13.732Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/51/8b08617af3ad95e33ce6d7dd2c99ed6c8298f7fb131636303956be022e25/pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c", size = 6344383, upload-time = "2026-07-01T11:54:15.756Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/72/cf78ac9780bb93c28328f408973845a309d4d145041665f734572ced1b52/pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df", size = 7052934, upload-time = "2026-07-01T11:54:17.721Z" },
-    { url = "https://files.pythonhosted.org/packages/20/20/25e0f4dc178a6bc0696793720055519a0de89e7661dae886992decbd2f81/pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f", size = 6472684, upload-time = "2026-07-01T11:54:19.839Z" },
-    { url = "https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09", size = 7227137, upload-time = "2026-07-01T11:54:22.025Z" },
-    { url = "https://files.pythonhosted.org/packages/de/47/4845a0a6c0dbf1db8456bd9fc791f13c5ced7ced20606d08a0aacfd25b49/pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510", size = 2568267, upload-time = "2026-07-01T11:54:24.051Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/ac/31fb64e1e7efb5a4b50cd3d92049ba89ac6e4d8d3bb6a74e15048ca3353e/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89", size = 4161684, upload-time = "2026-07-01T11:54:25.934Z" },
-    { url = "https://files.pythonhosted.org/packages/87/b4/9805e23d2b4d77842b468513841fda254ee42f0289d25088340e4ff46e2d/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace", size = 4255487, upload-time = "2026-07-01T11:54:27.935Z" },
-    { url = "https://files.pythonhosted.org/packages/df/39/ecf519435a200c693fe053a6ee4d835b41cf963a4dfc2551c4e637cb2a71/pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec", size = 3696433, upload-time = "2026-07-01T11:54:29.813Z" },
-    { url = "https://files.pythonhosted.org/packages/42/92/2fc3ffad878ae8dd5469ec1bc8eb83b71f48e13efdf68f02709003982a32/pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66", size = 5345889, upload-time = "2026-07-01T11:54:31.97Z" },
-    { url = "https://files.pythonhosted.org/packages/10/76/8803c13605b763d33d156c4678fc77f8443389c0c51c8aef707bb02015f4/pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35", size = 4780109, upload-time = "2026-07-01T11:54:34.026Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/01/e18aff37cb0b4aac47ac90f016d347a49aca667ef97f190b06ac2aabc928/pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65", size = 6263736, upload-time = "2026-07-01T11:54:36.131Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/62/de5bdd77d935331f4f802edc11e4d82950f642caad6cb2f949837b8560e2/pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3", size = 6937129, upload-time = "2026-07-01T11:54:38.216Z" },
-    { url = "https://files.pythonhosted.org/packages/70/4d/105627a13300c5e0df1d174230b32fd1273062c96f7745fd552b945d1e1d/pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a", size = 6339562, upload-time = "2026-07-01T11:54:40.354Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/1d/f13de01a553988ab895ba1c722e06cf3144d4f57656fd5b81b6d881f1179/pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e", size = 7049439, upload-time = "2026-07-01T11:54:42.489Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/f9/066794cca041b969964f779ee5fa66a9498bbf34248ac39c5d7954e4198f/pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f", size = 6473287, upload-time = "2026-07-01T11:54:44.9Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/9b/7a58e61d62be561da3a356fe2384d4059a6345fc130e23ef1c36a5b81d24/pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8", size = 7239691, upload-time = "2026-07-01T11:54:47.141Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/b0/c4ed4f0ef8f8fa5ee8351537db6650bb8189f7e118842978dd6589065692/pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b", size = 2568185, upload-time = "2026-07-01T11:54:49.137Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/01/001f65b68192f0228cc1dbbc8d2530ab5d58b61037ba0587f946fea607cd/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9cf95fe4d0f84c82d282745d9bb08ad9f926efa00be4697e767b814ce40d4330", size = 4161736, upload-time = "2026-07-01T11:54:51.156Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/d2/0219746d0fd16fc8a84498e79452375be3797d3ce4044596ce565164b84f/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:8728f216dcdb6e6d555cf971cb34076139ad74b31fc2c14da4fafc741c5f6217", size = 4255435, upload-time = "2026-07-01T11:54:53.414Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/02/8d0bc62ef0302318c46ff2a512822d2610e81c7aa46c9b3abe6cbaca5ad0/pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930", size = 3696262, upload-time = "2026-07-01T11:54:55.739Z" },
-    { url = "https://files.pythonhosted.org/packages/85/e2/73c77d218410b14f5f2d565e8a998d5317b7b9c75368d29985139f7a46f0/pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8", size = 5350344, upload-time = "2026-07-01T11:54:57.657Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0", size = 4780131, upload-time = "2026-07-01T11:54:59.713Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/9d/8b2c807dbef61a5197c047afe99823787eb66f63daf9fb2432f91d6f0462/pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321", size = 6263757, upload-time = "2026-07-01T11:55:01.778Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/44/c85361f65dbe00eea8576ee467c768d25129989efb76e94f205e9ca9bb46/pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b", size = 6936962, upload-time = "2026-07-01T11:55:03.93Z" },
-    { url = "https://files.pythonhosted.org/packages/18/7e/e483414b35800b86b6f08dbbc7803fb5cd52c4d6f897f47d53ea2c7e6f65/pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198", size = 6339171, upload-time = "2026-07-01T11:55:05.989Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/f4/68c491844841ede6bed70189546b3ee9731cf9f2cbad396faff5e1ccba45/pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130", size = 7048116, upload-time = "2026-07-01T11:55:08.131Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/34/77f3f793fed8efc7d243f21b33c5a3f0d1c97ee70346d3db855587e155ff/pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a", size = 6467209, upload-time = "2026-07-01T11:55:10.408Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/e0/492879f69d94f91f60fc8cd05ba03650e9520afebb2fb7aa12777d7c7f38/pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d", size = 7237707, upload-time = "2026-07-01T11:55:12.745Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/ac/6b11f2875f1c2ac040d84e1bbf9cf22a88038f901ca1037898b280b38365/pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838", size = 2565995, upload-time = "2026-07-01T11:55:14.736Z" },
-    { url = "https://files.pythonhosted.org/packages/52/69/c2208e56af9bfc1913afb24020297a691eb1d4ef688474c8a04913f65e04/pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e", size = 5352503, upload-time = "2026-07-01T11:55:17.076Z" },
-    { url = "https://files.pythonhosted.org/packages/07/70/e5686d753e898a45d778ff1718dba8516ead6ab6b95d85fc8c4b70650cf2/pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17", size = 4782956, upload-time = "2026-07-01T11:55:19.448Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/37/25c6692f06927ee973ff18c8d9ee98ad0b4d84ee67a09610c2dd1447958e/pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385", size = 6322855, upload-time = "2026-07-01T11:55:21.613Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/91/420637fcb8f1bc11029e403b4538e6694744428d8246118e45719f944556/pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c", size = 6989642, upload-time = "2026-07-01T11:55:24.006Z" },
-    { url = "https://files.pythonhosted.org/packages/10/08/b94d7811281ccf0d143a1cf768d1c49e1e54af63e7b708ab2ee3eb87face/pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d", size = 6391281, upload-time = "2026-07-01T11:55:26.252Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/87/24233f785f55474dc02ce3e739c5528a77e3a862e9333d1dd7a25cc31f70/pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931", size = 7096716, upload-time = "2026-07-01T11:55:28.318Z" },
-    { url = "https://files.pythonhosted.org/packages/23/26/fcb2f6e37175b04f53570b59937867e2b80ee1685e744023153028fc14f9/pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7", size = 6474125, upload-time = "2026-07-01T11:55:30.956Z" },
-    { url = "https://files.pythonhosted.org/packages/90/de/3634abee5f1c9e13c56787b7d5517b0ba8d6de51700b95578cf338349c9f/pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c", size = 7242939, upload-time = "2026-07-01T11:55:34.044Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/2a/fd13f8eb24de5714a6eb444a3d67e2842c6c576e159a43793adf23051351/pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45", size = 2567506, upload-time = "2026-07-01T11:55:35.988Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/dc/8fdce34ec725a33c81c6ba122b904d6b9024e50ea9ac7bede62fab54506c/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:0feb2e9d6ad6c9e3c06effe9d00f3f1e618a6643273576b016f591e9315a7139", size = 4162063, upload-time = "2026-07-01T11:55:37.941Z" },
-    { url = "https://files.pythonhosted.org/packages/76/66/2044b9a63d3b84ff048228dfcb7cd9bf0df983e8470971bf7d4c57b693de/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:9e881fca225083806662a5c43d627d215f258ff43c890f831966c7d7ba9c7402", size = 4255549, upload-time = "2026-07-01T11:55:40.022Z" },
-    { url = "https://files.pythonhosted.org/packages/52/7e/1f67e6f4ece6b582ee4b539decbcc9f848dc245a93ed8cd7338bafef72f1/pillow-12.3.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:4998562bf62a445225f22e07c896bb04b35b1b1f2eb6d760584c9c51d7a5f78c", size = 3696331, upload-time = "2026-07-01T11:55:41.98Z" },
-    { url = "https://files.pythonhosted.org/packages/12/40/d306fc2c8e4d45d7f175c77edca7063be7b86fe7fe6e68f4353bf71d808c/pillow-12.3.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:dc624f6bc473dacdf7ef7eb8678d0d08edf15cd94fad6ae5c7d6cc67a4e4902f", size = 5350370, upload-time = "2026-07-01T11:55:44.028Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/44/668fb1437e8ce420f62d6106eb66e44a5971602a4d794615bdf79315d82d/pillow-12.3.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:71d6097b330eea8fd15097780c8e89cb1a8ce7838669f48c5bacd6f663dd4701", size = 4780147, upload-time = "2026-07-01T11:55:46.073Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/08/93fa2e70e30a2d81547e481b6ee2bb9522117221fb1e0ce4b5df70967677/pillow-12.3.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28ce87c5ab450a9dd970b52e5aca5fe63ed432d18a2eaddd1979a00a1ba24ace", size = 6273659, upload-time = "2026-07-01T11:55:48.264Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/6d/043e96ff814fc31a33077e4cba86082167db520c93632afdf2042febbb0c/pillow-12.3.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b02afb9b97f65fbca5f31db6a2a3ba21aa93030225f150fa3f249717e938fb4", size = 6947439, upload-time = "2026-07-01T11:55:50.503Z" },
-    { url = "https://files.pythonhosted.org/packages/af/92/ba71d2ee2ac0edf3fa33bd9d5ee9ee080da70b1766f3ca3934f9938ddac9/pillow-12.3.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:1182d52bc2d5e5d7d0949503aa7e36d12f42205dc287e4883f407b1988820d39", size = 6353577, upload-time = "2026-07-01T11:55:52.697Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/ce/e63064e2122923ff687c8ad792d0d736a7b3920a56a46982e81a7fdd25d6/pillow-12.3.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e795b7eb908249c4e43c7c99fac7c2c75dab0c43566e37db472a355f63693d71", size = 7060394, upload-time = "2026-07-01T11:55:55.149Z" },
-    { url = "https://files.pythonhosted.org/packages/54/76/a09cc3ccc8d773a7283d34c38bec1708f9e3cc932093cbc4c5e71ac4060b/pillow-12.3.0-cp315-cp315-win32.whl", hash = "sha256:57b3d78c95ba9059768b10e28b813002261d3f3dfc55cc48b0c988f625175827", size = 6467375, upload-time = "2026-07-01T11:55:57.769Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/03/1846c49ba3b1d5550392a4bbd06d6fb4578e1cd91a803198b5c90f5f7d53/pillow-12.3.0-cp315-cp315-win_amd64.whl", hash = "sha256:fa4ecea169a355be7a3ade2c783e2ed12f0e40d2c5621cda8b3297faf7fbb9f5", size = 7237048, upload-time = "2026-07-01T11:55:59.975Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/bb/89f35dcc79610423f9f195504d7def7f0d1416a711541b42867e25fe3412/pillow-12.3.0-cp315-cp315-win_arm64.whl", hash = "sha256:877c3f311ff35410f690861c4409e7ccbf0cd2f878e50628a28e5a0bb689e658", size = 2566006, upload-time = "2026-07-01T11:56:02.143Z" },
-    { url = "https://files.pythonhosted.org/packages/30/88/707027ba09942dfa2c28759b5c222d769290a41c6d20ea60ec250801941f/pillow-12.3.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:e9871b1ffbfa9656b60aeee92ed5136a5742696006fa322b29ea3d8da0ecc9cf", size = 5352509, upload-time = "2026-07-01T11:56:04.2Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6d/00352fa25332c2569cd387851f568cc5a4b75a9adbfb37ac4fbce4c02eec/pillow-12.3.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53aa02d20d10c3d814d536aa4e5ac9b84ca0ff5a88377963b085ad6822f93e64", size = 4783167, upload-time = "2026-07-01T11:56:06.631Z" },
-    { url = "https://files.pythonhosted.org/packages/13/4f/9e049dfa21af7c22427275720e2490267ba8138120add5c4c574deb69782/pillow-12.3.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:446c34dcc4324b084a53b705127dc15717b22c5e140ae0a3c38349d4efec071e", size = 6329237, upload-time = "2026-07-01T11:56:08.868Z" },
-    { url = "https://files.pythonhosted.org/packages/36/16/cf6eeaae8d0fce8dd390a33437cf68c5d5bd73834a2bc6e2f14efda0ab45/pillow-12.3.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf1845d02ad822a369a49f2bb9345b1614744267682e7a03527dc3bf6eea1777", size = 6997047, upload-time = "2026-07-01T11:56:11.379Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/69/dbf769bdd55f48bf5733cac28edc6364ffaa072ec9ba336266e4fe66be55/pillow-12.3.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:186941b6aef820ad110fb01fb06eb925374dc3a21b17e37ec9a53b250c6fe2d1", size = 6400440, upload-time = "2026-07-01T11:56:13.908Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/e1/ffc9cfc2eea0d178da8018e18e959301ad9d6bc9f3edb7181e748a474b97/pillow-12.3.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f13c32a3abd6079a66d9526e18dad9b6d280384d49d7c54040cd57b6424041d9", size = 7105895, upload-time = "2026-07-01T11:56:16.575Z" },
-    { url = "https://files.pythonhosted.org/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload-time = "2026-07-01T11:56:18.855Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload-time = "2026-07-01T11:56:21.214Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload-time = "2026-07-01T11:56:23.506Z" },
-    { url = "https://files.pythonhosted.org/packages/75/18/2e8b40223153ccbc60df07f9e8928dc0c76202aa4e55ae9f53962b6510d6/pillow-12.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b3c777e849237620b022f7f297dd67705f9f5cf1685f09f02e46f93e92725468", size = 5302510, upload-time = "2026-07-01T11:56:25.736Z" },
-    { url = "https://files.pythonhosted.org/packages/46/3e/51fabf59d5ab801ceab709453d3ab6b180083496579549de4c45ced6528a/pillow-12.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b343699e8308bdc51978310e1c959c584e7869cc8c40780058c87da7781a1e94", size = 4736058, upload-time = "2026-07-01T11:56:28.041Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/20/22fe9384b7949e25fb1293bcfc84fb82590ff4ea6b37c95b24d26d793d86/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbd139c8447d25dd750ab79ee274cc5e1fe80fc56340ab10b18a195e1b6eca3e", size = 5237776, upload-time = "2026-07-01T11:56:30.263Z" },
-    { url = "https://files.pythonhosted.org/packages/08/14/f6ba68107680ffa74b39985f3f30884e41318fbc4250caa423c79b4788bb/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7e480451b9fa137494bccd3a7d69adbe8ac65a87d97be61e11f1b1050a5bac3", size = 5860358, upload-time = "2026-07-01T11:56:32.68Z" },
-    { url = "https://files.pythonhosted.org/packages/36/54/0169bc772ec491108b62f644f8ecf1fe5d8ae5ebafde2ee2142210166903/pillow-12.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a", size = 7231786, upload-time = "2026-07-01T11:56:35.046Z" },
 ]
 
 [[package]]
@@ -1373,27 +971,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9bad
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
     { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
-]
-
-[[package]]
-name = "proxy-tools"
-version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/cf/77d3e19b7fabd03895caca7857ef51e4c409e0ca6b37ee6e9f7daa50b642/proxy_tools-0.1.0.tar.gz", hash = "sha256:ccb3751f529c047e2d8a58440d86b205303cf0fe8146f784d1cbcd94f0a28010", size = 2978, upload-time = "2014-05-05T21:02:24.606Z" }
-
-[[package]]
-name = "psutil"
-version = "7.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/80/336820c1ad9286a4ded7e845b2eccfcb27851ab8ac6abece774a6ff4d3de/psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456", size = 497003, upload-time = "2025-02-13T21:54:07.946Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/e6/2d26234410f8b8abdbf891c9da62bee396583f713fb9f3325a4760875d22/psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25", size = 238051, upload-time = "2025-02-13T21:54:12.36Z" },
-    { url = "https://files.pythonhosted.org/packages/04/8b/30f930733afe425e3cbfc0e1468a30a18942350c1a8816acfade80c005c4/psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da", size = 239535, upload-time = "2025-02-13T21:54:16.07Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/ed/d362e84620dd22876b55389248e522338ed1bf134a5edd3b8231d7207f6d/psutil-7.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fcee592b4c6f146991ca55919ea3d1f8926497a713ed7faaf8225e174581e91", size = 275004, upload-time = "2025-02-13T21:54:18.662Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/b9/b0eb3f3cbcb734d930fdf839431606844a825b23eaf9a6ab371edac8162c/psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34", size = 277986, upload-time = "2025-02-13T21:54:21.811Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/a2/709e0fe2f093556c17fbafda93ac032257242cabcc7ff3369e2cb76a97aa/psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993", size = 279544, upload-time = "2025-02-13T21:54:24.68Z" },
-    { url = "https://files.pythonhosted.org/packages/50/e6/eecf58810b9d12e6427369784efe814a1eec0f492084ce8eb8f4d89d6d61/psutil-7.0.0-cp37-abi3-win32.whl", hash = "sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99", size = 241053, upload-time = "2025-02-13T21:54:34.31Z" },
-    { url = "https://files.pythonhosted.org/packages/50/1b/6921afe68c74868b4c9fa424dad3be35b095e16687989ebbb50ce4fceb7c/psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553", size = 244885, upload-time = "2025-02-13T21:54:37.486Z" },
 ]
 
 [[package]]
@@ -1518,34 +1095,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
-name = "pygls"
-version = "2.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "cattrs" },
-    { name = "lsprotocol" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/2e/7bbe061d175c0baddde8fc9edb908a4c31ba5d9165b8c68e3439c3a9f138/pygls-2.1.1.tar.gz", hash = "sha256:1da03ba9053201bb337dcdd8d121df70feb2a91e1a0dcc74de5da79755b1a201", size = 55091, upload-time = "2026-03-25T11:19:10.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/1a/208293b6c350f5abea6941d5606080d4a492644052504f5312e5de30a902/pygls-2.1.1-py3-none-any.whl", hash = "sha256:510a6dea2476177230c7d851125e5948efdf3fdb9ebfd8543fc434972f8faed4", size = 68975, upload-time = "2026-03-25T11:19:11.374Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1569,128 +1118,6 @@ crypto = [
 ]
 
 [[package]]
-name = "pyobjc-core"
-version = "12.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b4/b1/729f7458a63758bd21716648a8abcd9a0c8f2d2e9897763c8a1a1c7fd31b/pyobjc_core-12.2.1.tar.gz", hash = "sha256:7a7b9b018402342cf32bf1956366896350fbe5c0478cb3ef59778f77abed7f07", size = 1063383, upload-time = "2026-06-19T16:19:39.357Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/87/16564ef5e4568ee0edd9e712d8111dc8b67621d6bb6ff430646ee2d637dd/pyobjc_core-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:24b76a63caf0b5369d4a377c7c0438cd70df81539057af3db839bfaa3579e04a", size = 6484662, upload-time = "2026-06-19T16:04:44.979Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/88/300ad283bed0c971c52dcac6f70113e138169d4ce6d856ddd03d16081e51/pyobjc_core-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a64232bb27ed101d4adc7d42b0e64a6d3331aac7bee7861c037a6777a163f10b", size = 6433347, upload-time = "2026-06-19T16:04:49.341Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/1e/b9b0ddffae66996b8779f1f7958adc9f21c13a0448cd3be8d7fe589b5b0f/pyobjc_core-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:af101222762665a4125157906cb4b23f5d5a63d3851d5e0504f72a1eaaa2cfd2", size = 6436004, upload-time = "2026-06-19T16:04:53.257Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/26/bd309ede07784c6e5fac4b440c90a5f72a66da7859ed303a9392fe8a5f3f/pyobjc_core-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:efe465e3ecc6fc73f7c7622620345d134a8d34564ab1c29d8247e45f4ed55071", size = 6687044, upload-time = "2026-06-19T16:04:57.42Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/8a/cfa4f56939d554dbb342ec6e5226a441e2f552bc2002a0ddf7705bb11bef/pyobjc_core-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2b8fc0531c27277325e113ac00b8a72a82e6145f0a88175b9425d8de814ff69a", size = 6429289, upload-time = "2026-06-19T16:05:02.191Z" },
-    { url = "https://files.pythonhosted.org/packages/42/74/446c89bc18103aaa4a00d1fb85ff8acace9a0dc3f362d9678ebf7571e275/pyobjc_core-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9bef500f979e22d54f9da3aaebf6a48f873234b324858bd69256055a318955c7", size = 6690181, upload-time = "2026-06-19T16:05:06.201Z" },
-    { url = "https://files.pythonhosted.org/packages/99/c7/0121ee4c616af07ad2de8cd1a286f6978dc9a227eb58b7c2e875cb68a1df/pyobjc_core-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:047c226eeb58a2993ace5e8904e71cc9426ee20d064c617f8fbf32717d37093e", size = 6487078, upload-time = "2026-06-19T16:05:10.093Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/a8/cb9fcc150f97d0bf22a2028f88b24cc35949beb1bcc7b8bc5c17d4401677/pyobjc_core-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1188613805336270279570467e4455b74cb6c0f60913ac74c917ee1c37cfaecb", size = 6733064, upload-time = "2026-06-19T16:05:14.313Z" },
-]
-
-[[package]]
-name = "pyobjc-framework-cocoa"
-version = "12.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/d6/dc66ea8519a0475efbccf73f82cc28066339bb300a27f5e1bf91ab1d7002/pyobjc_framework_cocoa-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dc6da84f4fc62cc25463bbb85e77a57b8d5ac6caf9a60702daf2edb601332f15", size = 387298, upload-time = "2026-06-19T16:07:37.412Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/cf/1b3b32b2f28f66cc053c3438ef4e6df36a1591945bf05e7399da18d74553/pyobjc_framework_cocoa-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:28b9b8bab1c36efb94744786918752d0c1842f5fbb67e7d5ca97b5f736512080", size = 388113, upload-time = "2026-06-19T16:07:38.9Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/46/68e8e4d926a2f70fed0437047bc3f9fe08af8fe620d94d80656ebc3cfa9b/pyobjc_framework_cocoa-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3b74a78fa7803e547b32e5e8ec1b49987b52fe318383e793bc6cd49b80efbd9f", size = 388183, upload-time = "2026-06-19T16:07:40.483Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/f3/dfc9af4c9eb2e5389c860ad5ef252be9fe456db09f39d537555dc5057aa1/pyobjc_framework_cocoa-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dc2eaca2f13c7bcd8e41e51a372e47825dea9dd3126108760eed7ba883d2945c", size = 392275, upload-time = "2026-06-19T16:07:42.078Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/c8/b90baa8f3592eded79b4be98fb59d2b8dc16b62361e34292bd95806ebd9f/pyobjc_framework_cocoa-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b386c324d64ae565c1f6b7dfb77be68f640a1c7c23caa6966ab661131f519561", size = 388357, upload-time = "2026-06-19T16:07:43.364Z" },
-    { url = "https://files.pythonhosted.org/packages/98/d8/64a94651b9294702d55e748d94de30e25bc59d0784526be7643f4467eccd/pyobjc_framework_cocoa-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a6c584e2af0813cb2f6103b184e632665a26f58c1bd5b08ffd6e95a19c617f7b", size = 392404, upload-time = "2026-06-19T16:07:44.955Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/cc/26e8a7bf1f5e8caa38b7f80d486296f9fd3c97e71ad7e5444ef22e802758/pyobjc_framework_cocoa-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b6023657b8d6cc049a21bd6b4752425f2f53c42f9f0b02d64c7608cc484bf103", size = 388589, upload-time = "2026-06-19T16:07:46.276Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/f3/eedf743a303ea742b8e082afe3613fb4d6618bc1a48cf2568b004ce906f7/pyobjc_framework_cocoa-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c685ccd8e266a07cf912a2c5a13b1f2eff2a868a1aff163b4801b4687bd425e1", size = 392691, upload-time = "2026-06-19T16:07:47.477Z" },
-]
-
-[[package]]
-name = "pyobjc-framework-quartz"
-version = "12.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/08/527d1ff856e2f2446b5887be01989cc08f9adaf3de7d4eb13d07826c362f/pyobjc_framework_quartz-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:60f29408b4f9ed5391a29c6b63e2aa56ddfb8b66b3fb47962930427981e14462", size = 217998, upload-time = "2026-06-19T16:16:02.978Z" },
-    { url = "https://files.pythonhosted.org/packages/14/fc/d7c7b3134cdbd1a487f3f77b5be125d87a6c9e7d9411035739d99335cc0c/pyobjc_framework_quartz-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:de9c8cca7e95290c8d540466af11c7cdfe3a5458e6f56c34006d5b45243f9ed9", size = 219000, upload-time = "2026-06-19T16:16:04.29Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/4b/861f91a1565d3189ee899e177b915551fb9a7e2ca25414025a8974f04e74/pyobjc_framework_quartz-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:54c9bc7f507192691841ee4eba5bf36990b259df83ac728efed2d7ea1cd021e4", size = 219403, upload-time = "2026-06-19T16:16:05.645Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/b5/b27010d2f288737f627f74be6d5549f49c841542365c84b9a3011fe39ce7/pyobjc_framework_quartz-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:bfc0d2badd819823d21df8069dcf9544ce360ed747a8895c51bdb25d8d125f45", size = 224458, upload-time = "2026-06-19T16:16:07.252Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/5d/85ffd9d433989205d572a50d625c63b29c05e0c5235a725f15ae1023672c/pyobjc_framework_quartz-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ceb56939c337b36d9d81185ade31f77dc52c85cf79bb16e53e9b32f54b6bb3f5", size = 219769, upload-time = "2026-06-19T16:16:08.814Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/d6/b917e4b63d72ea84a27121076f3033f23f6497c0e6ce8d304766c899897f/pyobjc_framework_quartz-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8105c98b798f2bf81c05c54bddeeadbf62f0b5dfec13bd6e719dd2cdf7e1cddf", size = 224717, upload-time = "2026-06-19T16:16:10.215Z" },
-    { url = "https://files.pythonhosted.org/packages/04/e2/f3c1ed3228f7430ef5ade23db6f1fcbae99290f177ce5653348fd9e05f4d/pyobjc_framework_quartz-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:bbc214f1a216b5d3651bc832d0ac4589f029f3f37cd6cbb370aac12a7c77942c", size = 219825, upload-time = "2026-06-19T16:16:11.433Z" },
-    { url = "https://files.pythonhosted.org/packages/66/2a/2c99a5ad2fe0a11600ea123b8e9a08ff138fcb2ad1e13e376f4bd4aa1d96/pyobjc_framework_quartz-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ca61624a0b0e6286d8a0f97f47eb9011e4e81e9a339db436d48af527e7065bb1", size = 224770, upload-time = "2026-06-19T16:16:13.035Z" },
-]
-
-[[package]]
-name = "pyobjc-framework-security"
-version = "12.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/44/b8/4267b802d8dba6de468e7d0765b05cc4e146fa376ed9f55e0b6461016bef/pyobjc_framework_security-12.2.1.tar.gz", hash = "sha256:d7831b1537f4346892e7f2f0e2b09d79bee98919b0767f4061278d0e03028f2d", size = 181065, upload-time = "2026-06-19T16:21:40.151Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/ac/f2ff946edfaf16b4ce5e31afac5e519f83705c0f4842fd25134ecb8f2f4a/pyobjc_framework_security-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ce461296b003b2ba17c8b65f6339f9d2fd5dcfa2b3b52ddc0a696334cc8974c5", size = 41306, upload-time = "2026-06-19T16:17:16.816Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/5b/2719bc4062e6c27083191fd20e365ae02d0bf1c22f4d1a88211e3d96b369/pyobjc_framework_security-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:76ff6e44e62d3e15651540493879bf16687d862c4f10f3cadade757811c8b8d0", size = 41300, upload-time = "2026-06-19T16:17:17.702Z" },
-    { url = "https://files.pythonhosted.org/packages/15/90/dccd4cd6877ef208957dc1f3675287d8614a4dcd2a3ee0a5e56f5fb5a1ba/pyobjc_framework_security-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:990013baba29d6f985d8950b23701129b2597b3d16f628b785fe97596d8a8de3", size = 41299, upload-time = "2026-06-19T16:17:18.511Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/af/f9e8040e0c3ef6a50392a46ad1df482a666aa615180d40730b00282ff81f/pyobjc_framework_security-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:066a3e5e9d368e7a6ba8dd52be2077a634ef12a54fbfcc78b3b8154a8f988a1d", size = 42179, upload-time = "2026-06-19T16:17:19.48Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/3c/76e2a8bb8d5fe48f0e8e25c6abec1609f3667cc39935017badfe9e9603f2/pyobjc_framework_security-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:5319ae49b8874363ab51c6ff4d85d4ea0cfa6d836fe0306e901ba9ae560b880d", size = 41370, upload-time = "2026-06-19T16:17:20.501Z" },
-    { url = "https://files.pythonhosted.org/packages/14/6e/7120956e9833b2c70757eec1f65f57c191e00662cf74c4545d88315643fa/pyobjc_framework_security-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:21618431e0dbfbd3d4029445e3118af88e5d7e52ddecf9a2d17c759c51628d85", size = 42926, upload-time = "2026-06-19T16:17:21.425Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/ff/0bafc557523e5755f74dd5363386a1e9b03f611e2e36df0737a508cd5ab4/pyobjc_framework_security-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:fa192e9df479375e6242adcadb9a44f32907dd7fe1207608710cd3af65fe3c84", size = 41376, upload-time = "2026-06-19T16:17:22.337Z" },
-    { url = "https://files.pythonhosted.org/packages/47/33/33d266117e46fef148caa4f986b3d896cb9bfd76bef48bd761cb60c758ee/pyobjc_framework_security-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:07cd044a7996f9a897040c49055fa3bdf565acac4a25b834a72e60602376146d", size = 42944, upload-time = "2026-06-19T16:17:23.371Z" },
-]
-
-[[package]]
-name = "pyobjc-framework-uniformtypeidentifiers"
-version = "12.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/a1/108fa1e5a3dd8aff626f98fb97de370323b290404b04ffa2ef9420665ed3/pyobjc_framework_uniformtypeidentifiers-12.2.1.tar.gz", hash = "sha256:1fb89d13aa3c2df8e6d6536f6df3493fe5a6caefd2a5adebf17c5af3b29ed4a2", size = 20679, upload-time = "2026-06-19T16:21:55.739Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/44/18a7b3c3b4f9f6784fddf64ed5a2c148577d0300705a50e8ab81da8fc71d/pyobjc_framework_uniformtypeidentifiers-12.2.1-py2.py3-none-any.whl", hash = "sha256:ea08413ad895a7dfea13670e26548bcf5b00154084cdfb5d8f96603320e77cf3", size = 5042, upload-time = "2026-06-19T16:18:54.085Z" },
-]
-
-[[package]]
-name = "pyobjc-framework-webkit"
-version = "12.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/d2/b230c594f70ecb970b4cef67bae2648d1bfa5b381e9b7e3710bf24ec8887/pyobjc_framework_webkit-12.2.1.tar.gz", hash = "sha256:a56acae55b50d549b20dff2921ad1099add8fbc377d0de09ddc2ba50957f7def", size = 332374, upload-time = "2026-06-19T16:22:01.988Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/d3/2ab99d3975dd4624dd943e5a7c8d37e40258d3c9fcf4f26baf09a24e6c9b/pyobjc_framework_webkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:af5c4ccdf03845adac082823a3b4341b5b2fe62d2d664550afa705b5286a06fc", size = 50264, upload-time = "2026-06-19T16:19:30.607Z" },
-    { url = "https://files.pythonhosted.org/packages/84/47/7a2099eb2e062c6230a9440f1795cf34056ca5e16ef25c8aad7c059b8734/pyobjc_framework_webkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7e04dcc08cdc59380113ea1232af75a0a04c2426418ebe967b4c0045c973f776", size = 50372, upload-time = "2026-06-19T16:19:31.581Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/a4/202ec288808011d3f459d000d593e88b1118f2d1d5a4dfaaf5232f2c2ac2/pyobjc_framework_webkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:23bee8bf7077f91da4e3ae54a00c7f5e4414319e15f98be8584dbd67c4043fae", size = 50387, upload-time = "2026-06-19T16:19:32.522Z" },
-    { url = "https://files.pythonhosted.org/packages/95/a4/f796e94b43a66704b6ae17c747c7b97fd4b79348f1cfa9bef7b008aaa718/pyobjc_framework_webkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:00ffb254f97e9ffdd0a82c1faa61a07f6072ba900fa8aba70c83c21198b52e4e", size = 50853, upload-time = "2026-06-19T16:19:33.43Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/f6/d24716fef19ccc3d880e99029458803f0174c05df310d991eb97ea3a0799/pyobjc_framework_webkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:67030258c3cd66e8495ccfccef3d2d58010ff0209284c5115e5afdb0e9fd6de1", size = 50499, upload-time = "2026-06-19T16:19:34.45Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/6c/817119a52efcc229a30ceff56a0641005a431806a1f555e0571626ba313a/pyobjc_framework_webkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5d91527c9950c79269dd0d70f2bb8668c298dd06930637c1c063ce5f274a87e5", size = 50967, upload-time = "2026-06-19T16:19:35.474Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/59/5fac0754d53b2a72aed6f424dfc72e5fa245f83cb57c2e00d02e45390fca/pyobjc_framework_webkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:657825081484c9920c50b76b469b9583f116225b0449c9d95c46cbc8c640adc8", size = 50498, upload-time = "2026-06-19T16:19:36.397Z" },
-    { url = "https://files.pythonhosted.org/packages/da/0c/e997e33d99d4ad91da2cf70f0e51ac39b03c58ba210548e9e944bbb421be/pyobjc_framework_webkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f46adcc6227873f2b14d74b2e789c937f227722274ab59b9fa3c04c6ecb46dd5", size = 50958, upload-time = "2026-06-19T16:19:37.424Z" },
-]
-
-[[package]]
-name = "pystray"
-version = "0.19.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pillow" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
-    { name = "python-xlib", marker = "sys_platform == 'linux'" },
-    { name = "six" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/64/927a4b9024196a4799eba0180e0ca31568426f258a4a5c90f87a97f51d28/pystray-0.19.5-py2.py3-none-any.whl", hash = "sha256:a0c2229d02cf87207297c22d86ffc57c86c227517b038c0d3c59df79295ac617", size = 49068, upload-time = "2023-09-17T13:44:26.872Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1707,68 +1134,12 @@ wheels = [
 ]
 
 [[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
-]
-
-[[package]]
 name = "python-multipart"
 version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
-]
-
-[[package]]
-name = "python-xlib"
-version = "0.33"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six", marker = "sys_platform != 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/86/f5/8c0653e5bb54e0cbdfe27bf32d41f27bc4e12faa8742778c17f2a71be2c0/python-xlib-0.33.tar.gz", hash = "sha256:55af7906a2c75ce6cb280a584776080602444f75815a7aff4d287bb2d7018b32", size = 269068, upload-time = "2022-12-25T18:53:00.824Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl", hash = "sha256:c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398", size = 182185, upload-time = "2022-12-25T18:52:58.662Z" },
-]
-
-[[package]]
-name = "pythonnet"
-version = "3.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "clr-loader", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/57/da1992e44663b71365c6e842c8d7fa453d4ec45fb99a68cfee5b7e944d3c/pythonnet-3.1.0.tar.gz", hash = "sha256:7b34c382905d10a371509ffafd64cae0416305c28817738a9cd138336f4e9991", size = 250599, upload-time = "2026-05-23T20:30:21.578Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/4b/52414f442624d2589f5374a48c08d5ae94f24bea67fc13a20a752884e5b7/pythonnet-3.1.0-cp310.cp311.cp312.cp313.cp314-none-any.whl", hash = "sha256:698dd88edc198819ad63b624a6ebe76208c7b46e4fe13626f65e484f0358d6ba", size = 217578, upload-time = "2026-05-23T20:30:19.527Z" },
-    { url = "https://files.pythonhosted.org/packages/db/67/031124fdcb937c266a3265118525bbf6dc13b8c79786d6a7290aecb6e7bb/pythonnet-3.1.0-cp310.cp311.cp312.cp313.cp314-none-win32.win_amd64.whl", hash = "sha256:7bdd4de03df3547a48122a3989265c8b31d5be0d19dadffa009eec7df8085e0b", size = 1644898, upload-time = "2026-05-23T20:30:16.213Z" },
-]
-
-[[package]]
-name = "pywebview"
-version = "6.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "bottle" },
-    { name = "proxy-tools" },
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-security", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-uniformtypeidentifiers", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-webkit", marker = "sys_platform == 'darwin'" },
-    { name = "pythonnet", marker = "sys_platform == 'win32'" },
-    { name = "qtpy", marker = "sys_platform == 'openbsd6'" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/5d/a107645b073b80b4010e6fc62594dd58a958267b1b71439e7b89849362c7/pywebview-6.2.tar.gz", hash = "sha256:f51bfd095762fee3eb7821c62fe2c0ddd39c9fecd8f33d51a871113f12f364e1", size = 512668, upload-time = "2026-04-13T08:02:12.187Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/1c/78260d06d244d9138b8012eef541679f74e1e2b97e4e9dbf32a842b5b61a/pywebview-6.2-py3-none-any.whl", hash = "sha256:94681a1f456ed217f8a2139a1de612988c0d37cdb30d74d54279438e85572c41", size = 524555, upload-time = "2026-04-13T08:02:04.841Z" },
 ]
 
 [[package]]
@@ -1826,18 +1197,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
-]
-
-[[package]]
-name = "qtpy"
-version = "2.4.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging", marker = "sys_platform != 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/70/01/392eba83c8e47b946b929d7c46e0f04b35e9671f8bb6fc36b6f7945b4de8/qtpy-2.4.3.tar.gz", hash = "sha256:db744f7832e6d3da90568ba6ccbca3ee2b3b4a890c3d6fbbc63142f6e4cdf5bb", size = 66982, upload-time = "2025-02-11T15:09:25.759Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/76/37c0ccd5ab968a6a438f9c623aeecc84c202ab2fabc6a8fd927580c15b5a/QtPy-2.4.3-py3-none-any.whl", hash = "sha256:72095afe13673e017946cc258b8d5da43314197b741ed2890e563cf384b51aa1", size = 95045, upload-time = "2025-02-11T15:09:24.162Z" },
 ]
 
 [[package]]
@@ -1956,21 +1315,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/14/bd/ee13b20b763b8989f7c75d592bfd5de37dc1181814a2a2747fedcf97e3ba/regex-2026.2.28-cp314-cp314t-win32.whl", hash = "sha256:bbb882061f742eb5d46f2f1bd5304055be0a66b783576de3d7eef1bed4778a6e", size = 274936, upload-time = "2026-02-28T02:19:36.313Z" },
     { url = "https://files.pythonhosted.org/packages/cb/e7/d8020e39414c93af7f0d8688eabcecece44abfd5ce314b21dfda0eebd3d8/regex-2026.2.28-cp314-cp314t-win_amd64.whl", hash = "sha256:6591f281cb44dc13de9585b552cec6fc6cf47fb2fe7a48892295ee9bc4a612f9", size = 284779, upload-time = "2026-02-28T02:19:38.625Z" },
     { url = "https://files.pythonhosted.org/packages/13/c0/ad225f4a405827486f1955283407cf758b6d2fb966712644c5f5aef33d1b/regex-2026.2.28-cp314-cp314t-win_arm64.whl", hash = "sha256:dee50f1be42222f89767b64b283283ef963189da0dda4a515aa54a5563c62dec", size = 275010, upload-time = "2026-02-28T02:19:40.65Z" },
-]
-
-[[package]]
-name = "requests"
-version = "2.33.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]
@@ -2124,66 +1468,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ruamel-yaml"
-version = "0.18.14"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ruamel-yaml-clib", marker = "python_full_version < '3.14' and platform_python_implementation == 'CPython'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/39/87/6da0df742a4684263261c253f00edd5829e6aca970fff69e75028cccc547/ruamel.yaml-0.18.14.tar.gz", hash = "sha256:7227b76aaec364df15936730efbf7d72b30c0b79b1d578bbb8e3dcb2d81f52b7", size = 145511, upload-time = "2025-06-09T08:51:09.828Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/6d/6fe4805235e193aad4aaf979160dd1f3c487c57d48b810c816e6e842171b/ruamel.yaml-0.18.14-py3-none-any.whl", hash = "sha256:710ff198bb53da66718c7db27eec4fbcc9aa6ca7204e4c1df2f282b6fe5eb6b2", size = 118570, upload-time = "2025-06-09T08:51:06.348Z" },
-]
-
-[[package]]
-name = "ruamel-yaml-clib"
-version = "0.2.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ea/97/60fda20e2fb54b83a61ae14648b0817c8f5d84a3821e40bfbdae1437026a/ruamel_yaml_clib-0.2.15.tar.gz", hash = "sha256:46e4cc8c43ef6a94885f72512094e482114a8a706d3c555a34ed4b0d20200600", size = 225794, upload-time = "2025-11-16T16:12:59.761Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/80/8ce7b9af532aa94dd83360f01ce4716264db73de6bc8efd22c32341f6658/ruamel_yaml_clib-0.2.15-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c583229f336682b7212a43d2fa32c30e643d3076178fb9f7a6a14dde85a2d8bd", size = 147998, upload-time = "2025-11-16T16:13:13.241Z" },
-    { url = "https://files.pythonhosted.org/packages/53/09/de9d3f6b6701ced5f276d082ad0f980edf08ca67114523d1b9264cd5e2e0/ruamel_yaml_clib-0.2.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56ea19c157ed8c74b6be51b5fa1c3aff6e289a041575f0556f66e5fb848bb137", size = 132743, upload-time = "2025-11-16T16:13:14.265Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/f7/73a9b517571e214fe5c246698ff3ed232f1ef863c8ae1667486625ec688a/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5fea0932358e18293407feb921d4f4457db837b67ec1837f87074667449f9401", size = 731459, upload-time = "2025-11-16T20:22:44.338Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/a2/0dc0013169800f1c331a6f55b1282c1f4492a6d32660a0cf7b89e6684919/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef71831bd61fbdb7aa0399d5c4da06bea37107ab5c79ff884cc07f2450910262", size = 749289, upload-time = "2025-11-16T16:13:15.633Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/ed/3fb20a1a96b8dc645d88c4072df481fe06e0289e4d528ebbdcc044ebc8b3/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:617d35dc765715fa86f8c3ccdae1e4229055832c452d4ec20856136acc75053f", size = 777630, upload-time = "2025-11-16T16:13:16.898Z" },
-    { url = "https://files.pythonhosted.org/packages/60/50/6842f4628bc98b7aa4733ab2378346e1441e150935ad3b9f3c3c429d9408/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b45498cc81a4724a2d42273d6cfc243c0547ad7c6b87b4f774cb7bcc131c98d", size = 744368, upload-time = "2025-11-16T16:13:18.117Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/b0/128ae8e19a7d794c2e36130a72b3bb650ce1dd13fb7def6cf10656437dcf/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:def5663361f6771b18646620fca12968aae730132e104688766cf8a3b1d65922", size = 745233, upload-time = "2025-11-16T20:22:45.833Z" },
-    { url = "https://files.pythonhosted.org/packages/75/05/91130633602d6ba7ce3e07f8fc865b40d2a09efd4751c740df89eed5caf9/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:014181cdec565c8745b7cbc4de3bf2cc8ced05183d986e6d1200168e5bb59490", size = 770963, upload-time = "2025-11-16T16:13:19.344Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/4b/fd4542e7f33d7d1bc64cc9ac9ba574ce8cf145569d21f5f20133336cdc8c/ruamel_yaml_clib-0.2.15-cp311-cp311-win32.whl", hash = "sha256:d290eda8f6ada19e1771b54e5706b8f9807e6bb08e873900d5ba114ced13e02c", size = 102640, upload-time = "2025-11-16T16:13:20.498Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/eb/00ff6032c19c7537371e3119287999570867a0eafb0154fccc80e74bf57a/ruamel_yaml_clib-0.2.15-cp311-cp311-win_amd64.whl", hash = "sha256:bdc06ad71173b915167702f55d0f3f027fc61abd975bd308a0968c02db4a4c3e", size = 121996, upload-time = "2025-11-16T16:13:21.855Z" },
-    { url = "https://files.pythonhosted.org/packages/72/4b/5fde11a0722d676e469d3d6f78c6a17591b9c7e0072ca359801c4bd17eee/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cb15a2e2a90c8475df45c0949793af1ff413acfb0a716b8b94e488ea95ce7cff", size = 149088, upload-time = "2025-11-16T16:13:22.836Z" },
-    { url = "https://files.pythonhosted.org/packages/85/82/4d08ac65ecf0ef3b046421985e66301a242804eb9a62c93ca3437dc94ee0/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:64da03cbe93c1e91af133f5bec37fd24d0d4ba2418eaf970d7166b0a26a148a2", size = 134553, upload-time = "2025-11-16T16:13:24.151Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/cb/22366d68b280e281a932403b76da7a988108287adff2bfa5ce881200107a/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f6d3655e95a80325b84c4e14c080b2470fe4f33b6846f288379ce36154993fb1", size = 737468, upload-time = "2025-11-16T20:22:47.335Z" },
-    { url = "https://files.pythonhosted.org/packages/71/73/81230babf8c9e33770d43ed9056f603f6f5f9665aea4177a2c30ae48e3f3/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:71845d377c7a47afc6592aacfea738cc8a7e876d586dfba814501d8c53c1ba60", size = 753349, upload-time = "2025-11-16T16:13:26.269Z" },
-    { url = "https://files.pythonhosted.org/packages/61/62/150c841f24cda9e30f588ef396ed83f64cfdc13b92d2f925bb96df337ba9/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11e5499db1ccbc7f4b41f0565e4f799d863ea720e01d3e99fa0b7b5fcd7802c9", size = 788211, upload-time = "2025-11-16T16:13:27.441Z" },
-    { url = "https://files.pythonhosted.org/packages/30/93/e79bd9cbecc3267499d9ead919bd61f7ddf55d793fb5ef2b1d7d92444f35/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4b293a37dc97e2b1e8a1aec62792d1e52027087c8eea4fc7b5abd2bdafdd6642", size = 743203, upload-time = "2025-11-16T16:13:28.671Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/06/1eb640065c3a27ce92d76157f8efddb184bd484ed2639b712396a20d6dce/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:512571ad41bba04eac7268fe33f7f4742210ca26a81fe0c75357fa682636c690", size = 747292, upload-time = "2025-11-16T20:22:48.584Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/21/ee353e882350beab65fcc47a91b6bdc512cace4358ee327af2962892ff16/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5e9f630c73a490b758bf14d859a39f375e6999aea5ddd2e2e9da89b9953486a", size = 771624, upload-time = "2025-11-16T16:13:29.853Z" },
-    { url = "https://files.pythonhosted.org/packages/57/34/cc1b94057aa867c963ecf9ea92ac59198ec2ee3a8d22a126af0b4d4be712/ruamel_yaml_clib-0.2.15-cp312-cp312-win32.whl", hash = "sha256:f4421ab780c37210a07d138e56dd4b51f8642187cdfb433eb687fe8c11de0144", size = 100342, upload-time = "2025-11-16T16:13:31.067Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/e5/8925a4208f131b218f9a7e459c0d6fcac8324ae35da269cb437894576366/ruamel_yaml_clib-0.2.15-cp312-cp312-win_amd64.whl", hash = "sha256:2b216904750889133d9222b7b873c199d48ecbb12912aca78970f84a5aa1a4bc", size = 119013, upload-time = "2025-11-16T16:13:32.164Z" },
-    { url = "https://files.pythonhosted.org/packages/17/5e/2f970ce4c573dc30c2f95825f2691c96d55560268ddc67603dc6ea2dd08e/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dcec721fddbb62e60c2801ba08c87010bd6b700054a09998c4d09c08147b8fb", size = 147450, upload-time = "2025-11-16T16:13:33.542Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/03/a1baa5b94f71383913f21b96172fb3a2eb5576a4637729adbf7cd9f797f8/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:65f48245279f9bb301d1276f9679b82e4c080a1ae25e679f682ac62446fac471", size = 133139, upload-time = "2025-11-16T16:13:34.587Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/19/40d676802390f85784235a05788fd28940923382e3f8b943d25febbb98b7/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:46895c17ead5e22bea5e576f1db7e41cb273e8d062c04a6a49013d9f60996c25", size = 731474, upload-time = "2025-11-16T20:22:49.934Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/bb/6ef5abfa43b48dd55c30d53e997f8f978722f02add61efba31380d73e42e/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3eb199178b08956e5be6288ee0b05b2fb0b5c1f309725ad25d9c6ea7e27f962a", size = 748047, upload-time = "2025-11-16T16:13:35.633Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/5d/e4f84c9c448613e12bd62e90b23aa127ea4c46b697f3d760acc32cb94f25/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d1032919280ebc04a80e4fb1e93f7a738129857eaec9448310e638c8bccefcf", size = 782129, upload-time = "2025-11-16T16:13:36.781Z" },
-    { url = "https://files.pythonhosted.org/packages/de/4b/e98086e88f76c00c88a6bcf15eae27a1454f661a9eb72b111e6bbb69024d/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab0df0648d86a7ecbd9c632e8f8d6b21bb21b5fc9d9e095c796cacf32a728d2d", size = 736848, upload-time = "2025-11-16T16:13:37.952Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/5c/5964fcd1fd9acc53b7a3a5d9a05ea4f95ead9495d980003a557deb9769c7/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:331fb180858dd8534f0e61aa243b944f25e73a4dae9962bd44c46d1761126bbf", size = 741630, upload-time = "2025-11-16T20:22:51.718Z" },
-    { url = "https://files.pythonhosted.org/packages/07/1e/99660f5a30fceb58494598e7d15df883a07292346ef5696f0c0ae5dee8c6/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd4c928ddf6bce586285daa6d90680b9c291cfd045fc40aad34e445d57b1bf51", size = 766619, upload-time = "2025-11-16T16:13:39.178Z" },
-    { url = "https://files.pythonhosted.org/packages/36/2f/fa0344a9327b58b54970e56a27b32416ffbcfe4dcc0700605516708579b2/ruamel_yaml_clib-0.2.15-cp313-cp313-win32.whl", hash = "sha256:bf0846d629e160223805db9fe8cc7aec16aaa11a07310c50c8c7164efa440aec", size = 100171, upload-time = "2025-11-16T16:13:40.456Z" },
-    { url = "https://files.pythonhosted.org/packages/06/c4/c124fbcef0684fcf3c9b72374c2a8c35c94464d8694c50f37eef27f5a145/ruamel_yaml_clib-0.2.15-cp313-cp313-win_amd64.whl", hash = "sha256:45702dfbea1420ba3450bb3dd9a80b33f0badd57539c6aac09f42584303e0db6", size = 118845, upload-time = "2025-11-16T16:13:41.481Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/bd/ab8459c8bb759c14a146990bf07f632c1cbec0910d4853feeee4be2ab8bb/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:753faf20b3a5906faf1fc50e4ddb8c074cb9b251e00b14c18b28492f933ac8ef", size = 147248, upload-time = "2025-11-16T16:13:42.872Z" },
-    { url = "https://files.pythonhosted.org/packages/69/f2/c4cec0a30f1955510fde498aac451d2e52b24afdbcb00204d3a951b772c3/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:480894aee0b29752560a9de46c0e5f84a82602f2bc5c6cde8db9a345319acfdf", size = 133764, upload-time = "2025-11-16T16:13:43.932Z" },
-    { url = "https://files.pythonhosted.org/packages/82/c7/2480d062281385a2ea4f7cc9476712446e0c548cd74090bff92b4b49e898/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d3b58ab2454b4747442ac76fab66739c72b1e2bb9bd173d7694b9f9dbc9c000", size = 730537, upload-time = "2025-11-16T20:22:52.918Z" },
-    { url = "https://files.pythonhosted.org/packages/75/08/e365ee305367559f57ba6179d836ecc3d31c7d3fdff2a40ebf6c32823a1f/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bfd309b316228acecfa30670c3887dcedf9b7a44ea39e2101e75d2654522acd4", size = 746944, upload-time = "2025-11-16T16:13:45.338Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/5c/8b56b08db91e569d0a4fbfa3e492ed2026081bdd7e892f63ba1c88a2f548/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2812ff359ec1f30129b62372e5f22a52936fac13d5d21e70373dbca5d64bb97c", size = 778249, upload-time = "2025-11-16T16:13:46.871Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/1d/70dbda370bd0e1a92942754c873bd28f513da6198127d1736fa98bb2a16f/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7e74ea87307303ba91073b63e67f2c667e93f05a8c63079ee5b7a5c8d0d7b043", size = 737140, upload-time = "2025-11-16T16:13:48.349Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/87/822d95874216922e1120afb9d3fafa795a18fdd0c444f5c4c382f6dac761/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:713cd68af9dfbe0bb588e144a61aad8dcc00ef92a82d2e87183ca662d242f524", size = 741070, upload-time = "2025-11-16T20:22:54.151Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/17/4e01a602693b572149f92c983c1f25bd608df02c3f5cf50fd1f94e124a59/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:542d77b72786a35563f97069b9379ce762944e67055bea293480f7734b2c7e5e", size = 765882, upload-time = "2025-11-16T16:13:49.526Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/17/7999399081d39ebb79e807314de6b611e1d1374458924eb2a489c01fc5ad/ruamel_yaml_clib-0.2.15-cp314-cp314-win32.whl", hash = "sha256:424ead8cef3939d690c4b5c85ef5b52155a231ff8b252961b6516ed7cf05f6aa", size = 102567, upload-time = "2025-11-16T16:13:50.78Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/67/be582a7370fdc9e6846c5be4888a530dcadd055eef5b932e0e85c33c7d73/ruamel_yaml_clib-0.2.15-cp314-cp314-win_amd64.whl", hash = "sha256:ac9b8d5fa4bb7fd2917ab5027f60d4234345fd366fe39aa711d5dca090aa1467", size = 122847, upload-time = "2025-11-16T16:13:51.807Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.15.20"
 source = { registry = "https://pypi.org/simple" }
@@ -2261,18 +1545,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sensai-utils"
-version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/dd/faa2e2de71a03af3def212c70777e794dd54ad5ab87927bb5c29f85f24fc/sensai_utils-1.5.0.tar.gz", hash = "sha256:2ca709a0d5807caf1632d665a455c173987b25276ce61693021672e875f0f17b", size = 61677, upload-time = "2025-07-28T22:46:10.148Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/d5/62a0e693230bace8e9a767d6d187a4d9421a7c6ee4b48551f8ff7bd1629a/sensai_utils-1.5.0-py3-none-any.whl", hash = "sha256:c23c51d23d353e7a9b77c70aa8ba7f2d0a8fe4e67ee5bc1ef41c69dba5e4befb", size = 68836, upload-time = "2025-07-28T22:46:08.929Z" },
-]
-
-[[package]]
 name = "sentencepiece"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2299,73 +1571,12 @@ wheels = [
 ]
 
 [[package]]
-name = "serena-agent"
-version = "1.5.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anthropic" },
-    { name = "beautifulsoup4" },
-    { name = "cryptography" },
-    { name = "docstring-parser" },
-    { name = "dotenv" },
-    { name = "filelock" },
-    { name = "flask" },
-    { name = "jinja2" },
-    { name = "joblib" },
-    { name = "lsprotocol" },
-    { name = "mcp" },
-    { name = "overrides" },
-    { name = "pathspec" },
-    { name = "psutil" },
-    { name = "pydantic" },
-    { name = "pygls" },
-    { name = "pystray" },
-    { name = "python-dotenv" },
-    { name = "python-multipart" },
-    { name = "pythonnet", marker = "sys_platform == 'win32'" },
-    { name = "pywebview" },
-    { name = "pyyaml" },
-    { name = "regex" },
-    { name = "requests" },
-    { name = "ruamel-yaml" },
-    { name = "sensai-utils" },
-    { name = "starlette" },
-    { name = "tiktoken" },
-    { name = "tqdm" },
-    { name = "types-pyyaml" },
-    { name = "urllib3" },
-    { name = "werkzeug" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/ca/87430cc8e8dfc32485539f34dbd3c2424c48c8a5a51cb0452db45c318b6c/serena_agent-1.5.3.tar.gz", hash = "sha256:eb384608e11b75fbc29196dd942f6da28946060888ee5b22e76af216825f678e", size = 1995929, upload-time = "2026-05-26T19:06:30.079Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/ab/6ea975941b3efecc80500f99c060866ffe1a20a59e2a7ac60dfa6d083a52/serena_agent-1.5.3-py3-none-any.whl", hash = "sha256:dc08b98e0e3cb2bcf80be1eb1054a4009b118a49b654763e710d9d5805129503", size = 911972, upload-time = "2026-05-26T19:06:28.424Z" },
-]
-
-[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]
@@ -2382,15 +1593,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/a1/d19dd9889cd4bce2e233c4fac007cd8daaf5b9fe6e6a5d432cf17be0b807/sounddevice-0.5.5-py3-none-win32.whl", hash = "sha256:1234cc9b4c9df97b6cbe748146ae0ec64dd7d6e44739e8e42eaa5b595313a103", size = 317765, upload-time = "2026-01-23T18:36:39.047Z" },
     { url = "https://files.pythonhosted.org/packages/c3/0e/002ed7c4c1c2ab69031f78989d3b789fee3a7fba9e586eb2b81688bf4961/sounddevice-0.5.5-py3-none-win_amd64.whl", hash = "sha256:cfc6b2c49fb7f555591c78cb8ecf48d6a637fd5b6e1db5fec6ed9365d64b3519", size = 365324, upload-time = "2026-01-23T18:36:40.496Z" },
     { url = "https://files.pythonhosted.org/packages/4e/39/a61d4b83a7746b70d23d9173be688c0c6bfc7173772344b7442c2c155497/sounddevice-0.5.5-py3-none-win_arm64.whl", hash = "sha256:3861901ddd8230d2e0e8ae62ac320cdd4c688d81df89da036dcb812f757bb3e6", size = 317115, upload-time = "2026-01-23T18:36:42.235Z" },
-]
-
-[[package]]
-name = "soupsieve"
-version = "2.8.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
@@ -2417,60 +1619,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
-]
-
-[[package]]
-name = "tiktoken"
-version = "0.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "regex" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/46/21ea696b21f1d6d1efec8639c204bdf20fde8bafb351e1355c72c5d7de52/tiktoken-0.12.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6e227c7f96925003487c33b1b32265fad2fbcec2b7cf4817afb76d416f40f6bb", size = 1051565, upload-time = "2025-10-06T20:21:44.566Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/d9/35c5d2d9e22bb2a5f74ba48266fb56c63d76ae6f66e02feb628671c0283e/tiktoken-0.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c06cf0fcc24c2cb2adb5e185c7082a82cba29c17575e828518c2f11a01f445aa", size = 995284, upload-time = "2025-10-06T20:21:45.622Z" },
-    { url = "https://files.pythonhosted.org/packages/01/84/961106c37b8e49b9fdcf33fe007bb3a8fdcc380c528b20cc7fbba80578b8/tiktoken-0.12.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:f18f249b041851954217e9fd8e5c00b024ab2315ffda5ed77665a05fa91f42dc", size = 1129201, upload-time = "2025-10-06T20:21:47.074Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/d0/3d9275198e067f8b65076a68894bb52fd253875f3644f0a321a720277b8a/tiktoken-0.12.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:47a5bc270b8c3db00bb46ece01ef34ad050e364b51d406b6f9730b64ac28eded", size = 1152444, upload-time = "2025-10-06T20:21:48.139Z" },
-    { url = "https://files.pythonhosted.org/packages/78/db/a58e09687c1698a7c592e1038e01c206569b86a0377828d51635561f8ebf/tiktoken-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:508fa71810c0efdcd1b898fda574889ee62852989f7c1667414736bcb2b9a4bd", size = 1195080, upload-time = "2025-10-06T20:21:49.246Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1b/a9e4d2bf91d515c0f74afc526fd773a812232dd6cda33ebea7f531202325/tiktoken-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a1af81a6c44f008cba48494089dd98cccb8b313f55e961a52f5b222d1e507967", size = 1255240, upload-time = "2025-10-06T20:21:50.274Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/15/963819345f1b1fb0809070a79e9dd96938d4ca41297367d471733e79c76c/tiktoken-0.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:3e68e3e593637b53e56f7237be560f7a394451cb8c11079755e80ae64b9e6def", size = 879422, upload-time = "2025-10-06T20:21:51.734Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/85/be65d39d6b647c79800fd9d29241d081d4eeb06271f383bb87200d74cf76/tiktoken-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b97f74aca0d78a1ff21b8cd9e9925714c15a9236d6ceacf5c7327c117e6e21e8", size = 1050728, upload-time = "2025-10-06T20:21:52.756Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/42/6573e9129bc55c9bf7300b3a35bef2c6b9117018acca0dc760ac2d93dffe/tiktoken-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b90f5ad190a4bb7c3eb30c5fa32e1e182ca1ca79f05e49b448438c3e225a49b", size = 994049, upload-time = "2025-10-06T20:21:53.782Z" },
-    { url = "https://files.pythonhosted.org/packages/66/c5/ed88504d2f4a5fd6856990b230b56d85a777feab84e6129af0822f5d0f70/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65b26c7a780e2139e73acc193e5c63ac754021f160df919add909c1492c0fb37", size = 1129008, upload-time = "2025-10-06T20:21:54.832Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/90/3dae6cc5436137ebd38944d396b5849e167896fc2073da643a49f372dc4f/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:edde1ec917dfd21c1f2f8046b86348b0f54a2c0547f68149d8600859598769ad", size = 1152665, upload-time = "2025-10-06T20:21:56.129Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/fe/26df24ce53ffde419a42f5f53d755b995c9318908288c17ec3f3448313a3/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:35a2f8ddd3824608b3d650a000c1ef71f730d0c56486845705a8248da00f9fe5", size = 1194230, upload-time = "2025-10-06T20:21:57.546Z" },
-    { url = "https://files.pythonhosted.org/packages/20/cc/b064cae1a0e9fac84b0d2c46b89f4e57051a5f41324e385d10225a984c24/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d16643edb7fa2c99eff2ab7733508aae1eebb03d5dfc46f5565862810f24e3", size = 1254688, upload-time = "2025-10-06T20:21:58.619Z" },
-    { url = "https://files.pythonhosted.org/packages/81/10/b8523105c590c5b8349f2587e2fdfe51a69544bd5a76295fc20f2374f470/tiktoken-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc5288f34a8bc02e1ea7047b8d041104791d2ddbf42d1e5fa07822cbffe16bd", size = 878694, upload-time = "2025-10-06T20:21:59.876Z" },
-    { url = "https://files.pythonhosted.org/packages/00/61/441588ee21e6b5cdf59d6870f86beb9789e532ee9718c251b391b70c68d6/tiktoken-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:775c2c55de2310cc1bc9a3ad8826761cbdc87770e586fd7b6da7d4589e13dab3", size = 1050802, upload-time = "2025-10-06T20:22:00.96Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/05/dcf94486d5c5c8d34496abe271ac76c5b785507c8eae71b3708f1ad9b45a/tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160", size = 993995, upload-time = "2025-10-06T20:22:02.788Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/70/5163fe5359b943f8db9946b62f19be2305de8c3d78a16f629d4165e2f40e/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:01d99484dc93b129cd0964f9d34eee953f2737301f18b3c7257bf368d7615baa", size = 1128948, upload-time = "2025-10-06T20:22:03.814Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/da/c028aa0babf77315e1cef357d4d768800c5f8a6de04d0eac0f377cb619fa/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be", size = 1151986, upload-time = "2025-10-06T20:22:05.173Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/5a/886b108b766aa53e295f7216b509be95eb7d60b166049ce2c58416b25f2a/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:981a81e39812d57031efdc9ec59fa32b2a5a5524d20d4776574c4b4bd2e9014a", size = 1194222, upload-time = "2025-10-06T20:22:06.265Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f8/4db272048397636ac7a078d22773dd2795b1becee7bc4922fe6207288d57/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3", size = 1255097, upload-time = "2025-10-06T20:22:07.403Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/32/45d02e2e0ea2be3a9ed22afc47d93741247e75018aac967b713b2941f8ea/tiktoken-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b8a0cd0c789a61f31bf44851defbd609e8dd1e2c8589c614cc1060940ef1f697", size = 879117, upload-time = "2025-10-06T20:22:08.418Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/76/994fc868f88e016e6d05b0da5ac24582a14c47893f4474c3e9744283f1d5/tiktoken-0.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d5f89ea5680066b68bcb797ae85219c72916c922ef0fcdd3480c7d2315ffff16", size = 1050309, upload-time = "2025-10-06T20:22:10.939Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/b8/57ef1456504c43a849821920d582a738a461b76a047f352f18c0b26c6516/tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a", size = 993712, upload-time = "2025-10-06T20:22:12.115Z" },
-    { url = "https://files.pythonhosted.org/packages/72/90/13da56f664286ffbae9dbcfadcc625439142675845baa62715e49b87b68b/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fc530a28591a2d74bce821d10b418b26a094bf33839e69042a6e86ddb7a7fb27", size = 1128725, upload-time = "2025-10-06T20:22:13.541Z" },
-    { url = "https://files.pythonhosted.org/packages/05/df/4f80030d44682235bdaecd7346c90f67ae87ec8f3df4a3442cb53834f7e4/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb", size = 1151875, upload-time = "2025-10-06T20:22:14.559Z" },
-    { url = "https://files.pythonhosted.org/packages/22/1f/ae535223a8c4ef4c0c1192e3f9b82da660be9eb66b9279e95c99288e9dab/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:04f0e6a985d95913cabc96a741c5ffec525a2c72e9df086ff17ebe35985c800e", size = 1194451, upload-time = "2025-10-06T20:22:15.545Z" },
-    { url = "https://files.pythonhosted.org/packages/78/a7/f8ead382fce0243cb625c4f266e66c27f65ae65ee9e77f59ea1653b6d730/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25", size = 1253794, upload-time = "2025-10-06T20:22:16.624Z" },
-    { url = "https://files.pythonhosted.org/packages/93/e0/6cc82a562bc6365785a3ff0af27a2a092d57c47d7a81d9e2295d8c36f011/tiktoken-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dc2dd125a62cb2b3d858484d6c614d136b5b848976794edfb63688d539b8b93f", size = 878777, upload-time = "2025-10-06T20:22:18.036Z" },
-    { url = "https://files.pythonhosted.org/packages/72/05/3abc1db5d2c9aadc4d2c76fa5640134e475e58d9fbb82b5c535dc0de9b01/tiktoken-0.12.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a90388128df3b3abeb2bfd1895b0681412a8d7dc644142519e6f0a97c2111646", size = 1050188, upload-time = "2025-10-06T20:22:19.563Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/7b/50c2f060412202d6c95f32b20755c7a6273543b125c0985d6fa9465105af/tiktoken-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:da900aa0ad52247d8794e307d6446bd3cdea8e192769b56276695d34d2c9aa88", size = 993978, upload-time = "2025-10-06T20:22:20.702Z" },
-    { url = "https://files.pythonhosted.org/packages/14/27/bf795595a2b897e271771cd31cb847d479073497344c637966bdf2853da1/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:285ba9d73ea0d6171e7f9407039a290ca77efcdb026be7769dccc01d2c8d7fff", size = 1129271, upload-time = "2025-10-06T20:22:22.06Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/de/9341a6d7a8f1b448573bbf3425fa57669ac58258a667eb48a25dfe916d70/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d186a5c60c6a0213f04a7a802264083dea1bbde92a2d4c7069e1a56630aef830", size = 1151216, upload-time = "2025-10-06T20:22:23.085Z" },
-    { url = "https://files.pythonhosted.org/packages/75/0d/881866647b8d1be4d67cb24e50d0c26f9f807f994aa1510cb9ba2fe5f612/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:604831189bd05480f2b885ecd2d1986dc7686f609de48208ebbbddeea071fc0b", size = 1194860, upload-time = "2025-10-06T20:22:24.602Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/1e/b651ec3059474dab649b8d5b69f5c65cd8fcd8918568c1935bd4136c9392/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8f317e8530bb3a222547b85a58583238c8f74fd7a7408305f9f63246d1a0958b", size = 1254567, upload-time = "2025-10-06T20:22:25.671Z" },
-    { url = "https://files.pythonhosted.org/packages/80/57/ce64fd16ac390fafde001268c364d559447ba09b509181b2808622420eec/tiktoken-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:399c3dd672a6406719d84442299a490420b458c44d3ae65516302a99675888f3", size = 921067, upload-time = "2025-10-06T20:22:26.753Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/a4/72eed53e8976a099539cdd5eb36f241987212c29629d0a52c305173e0a68/tiktoken-0.12.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2c714c72bc00a38ca969dae79e8266ddec999c7ceccd603cc4f0d04ccd76365", size = 1050473, upload-time = "2025-10-06T20:22:27.775Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/d7/0110b8f54c008466b19672c615f2168896b83706a6611ba6e47313dbc6e9/tiktoken-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cbb9a3ba275165a2cb0f9a83f5d7025afe6b9d0ab01a22b50f0e74fee2ad253e", size = 993855, upload-time = "2025-10-06T20:22:28.799Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/77/4f268c41a3957c418b084dd576ea2fad2e95da0d8e1ab705372892c2ca22/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:dfdfaa5ffff8993a3af94d1125870b1d27aed7cb97aa7eb8c1cefdbc87dbee63", size = 1129022, upload-time = "2025-10-06T20:22:29.981Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/2b/fc46c90fe5028bd094cd6ee25a7db321cb91d45dc87531e2bdbb26b4867a/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:584c3ad3d0c74f5269906eb8a659c8bfc6144a52895d9261cdaf90a0ae5f4de0", size = 1150736, upload-time = "2025-10-06T20:22:30.996Z" },
-    { url = "https://files.pythonhosted.org/packages/28/c0/3c7a39ff68022ddfd7d93f3337ad90389a342f761c4d71de99a3ccc57857/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a", size = 1194908, upload-time = "2025-10-06T20:22:32.073Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/0d/c1ad6f4016a3968c048545f5d9b8ffebf577774b2ede3e2e352553b685fe/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0", size = 1253706, upload-time = "2025-10-06T20:22:33.385Z" },
-    { url = "https://files.pythonhosted.org/packages/af/df/c7891ef9d2712ad774777271d39fdef63941ffba0a9d59b7ad1fd2765e57/tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71", size = 920667, upload-time = "2025-10-06T20:22:34.444Z" },
 ]
 
 [[package]]
@@ -2590,6 +1738,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2635,15 +1792,6 @@ wheels = [
 ]
 
 [[package]]
-name = "urllib3"
-version = "2.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
-]
-
-[[package]]
 name = "uvicorn"
 version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2663,16 +1811,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
-]
-
-[[package]]
-name = "werkzeug"
-version = "3.1.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/43/76ded108b296a49f52de6bac5192ca1c4be84e886f9b5c9ba8427d9694fd/werkzeug-3.1.7.tar.gz", hash = "sha256:fb8c01fe6ab13b9b7cdb46892b99b1d66754e1d7ab8e542e865ec13f526b5351", size = 875700, upload-time = "2026-03-24T01:08:07.687Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/b2/0bba9bbb4596d2d2f285a16c2ab04118f6b957d8441566e1abb892e6a6b2/werkzeug-3.1.7-py3-none-any.whl", hash = "sha256:4b314d81163a3e1a169b6a0be2a000a0e204e8873c5de6586f453c55688d422f", size = 226295, upload-time = "2026-03-24T01:08:06.133Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -195,7 +195,7 @@ wheels = [
 
 [[package]]
 name = "chad-code"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },
@@ -237,7 +237,7 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=1.22.0" },
     { name = "jedi", specifier = ">=0.19.2" },
     { name = "jinja2", specifier = ">=3.1" },
-    { name = "mcp", specifier = ">=1.27" },
+    { name = "mcp", specifier = ">=1.27,<2" },
     { name = "mlx", marker = "sys_platform == 'darwin'", specifier = ">=0.32.0,<0.33" },
     { name = "mlx-lm", marker = "sys_platform == 'darwin'", specifier = ">=0.31.3,<0.32" },
     { name = "numpy", specifier = ">=1.26,<3" },


### PR DESCRIPTION
- **Precision code intelligence now ships in the base install.** `find_refs` /
  `rename_symbol` precision used to live behind an optional `lsp` extra
  (`serena-agent`, 33 transitive dependencies) that `uvx chad-code` never installed —
  so every published install ran name-match only. chad now drives language servers
  through its own ~350-line LSP client (`lspclient.py`) plus a declarative registry
  (`lspservers.py`, the nvim-lspconfig shape): pyright via uvx (guaranteed present on
  the uvx install path), the TypeScript 7 native LSP via npx, gopls / rust-analyzer /
  clangd / solargraph / intelephense from PATH. Zero new Python dependencies; the
  `lsp` extra and serena-agent are gone. Servers that would answer confidently-wrong
  empties without project context (clangd without `compile_commands.json`, TS without
  a `tsconfig`) are refused, keeping the honestly-labeled name-match fallback.
- **Qualified symbol paths in every language.** `view_symbol("Engine/process")`,
  `replace_symbol("Engine.process", …)` etc. now resolve the method — not a same-named
  free function — in Python, TS/JS, Go, Rust, Java, Ruby, C#, PHP, Kotlin and C++
  alike, via scope chains derived from tree-sitter spans (plus receiver/impl context
  for Go/Rust/C++, whose methods don't nest lexically). This was Python-only via
  jedi before; jedi is deleted and every language takes one code path (verified
  against jedi on this repo: 230/230 span-identical). A qualified path whose
  container doesn't match is now a miss instead of silently editing the bare name.
- **Broken grammars fixed for 4 of 12 fixture languages — and shell added outright.**
  First polyglot measurement found the language pack ships NO tags query for
  TypeScript/TSX, a PHP query that doesn't compile against the current grammar, C
  with no reference captures, and C++ missing out-of-class method definitions. chad
  now carries its own tags queries for those (`repomap._TAGS_OVERRIDE`), plus a new
  bash query the pack never had: shell functions and top-level variables now appear
  in `repo_map`/`overview`, `find_refs` finds invocations across scripts, and
  `replace_symbol` edits a shell function by name — shell is the one surface nearly
  every real repo (and 89 of 91 terminal-bench-2.1 tasks) contains. All pinned by a
  13-language coverage test.
- **Post-edit typecheck in the edit result.** When a language server is warm, every
  edit/symbol-edit result appends the server's type errors (errors only, capped,
  ~50 tokens) — a type error surfaces immediately instead of one failed test run
  later. Edits never pay a cold server start (lever: `post_edit_diagnostics`).
- **New `hover` tool.** The resolved type signature + docs of one symbol via the
  language server — one line instead of opening the defining file.
- **mcp 2.x, single code path.** The `mcp<2` cap (below) was serena-agent collateral;
  with serena gone chad runs natively on mcp 2.0 (protocol 2026-07-28). The two
  renames that fail silently through getattr defaults (`isError`→`is_error`,
  `readOnlyHint`→`read_only_hint`) are each pinned by a test that fails on the 1.x
  spelling.
- **Fixes a broken install.** `uvx chad-code` (and any other fresh resolve) crashed on
  startup with `ImportError: cannot import name 'streamablehttp_client'`. The `mcp`
  dependency was unbounded, so a clean resolve picked up the SDK's 2.0 major, which
  removed the HTTP transport chad uses, moved to `httpx2`, and split the wire types into
  a separate distribution. (The cap has since become the deliberate 2.x port above.)
- **A broken MCP SDK can no longer take the agent down.** Every other MCP failure already
  degraded — a server that's missing, misconfigured, or crashing costs you its tools and
  nothing else — but the SDK import itself ran unguarded at `chad.mcp` load, which happens
  on every Agent. It's guarded now: an incompatible SDK means no MCP tools plus one
  warning line in `/mcp`, and the rest of chad runs. Relatedly, `/mcp` no longer reports
  "no MCP servers configured" when servers *are* configured but all failed — it shows the
  warnings that explain why.
- **CI now catches this class of break.** The fresh-resolve job and the weekly install
  canary only ran `chad --help`, which exits inside argparse and never imports the modules
  that load on the first turn. Both now import every `chad` submodule against a clean
  resolve and fail if the MCP SDK guard fires.