### PR TITLE
speech packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Notable, user-visible changes.
 
+## [1.0.8] — 2026-07-29
+
+- **`/speech` now names an install command that can actually work.** The voice-mode
+  install hint was hardcoded to `uv sync --extra speech` — true only in a git clone, so
+  every published install (`uvx chad-code`, `uv tool install chad-code`) was sent to a
+  command with no project to sync. An extra rides on the *install spec*, not on a
+  separate step, and `speech.install_hint()` now derives the right form from how chad was
+  actually installed: `uv tool install --force 'chad-code[speech]'`, `uvx --from
+  'chad-code[speech]' chad`, `uv sync --extra speech` in a clone, or `uv pip install
+  'chad-code[speech]'` in a plain venv.
+- **Extras documented in one place.** The README install section now states the
+  install-spec rule with all three commands side by side, so the PyPI project page
+  carries it too. Also drops a stale line claiming LSP-precise find-refs/rename need an
+  `lsp` extra — that extra is gone and precision ships in the base install as of 1.0.7.
+
 ## [1.0.7] — 2026-07-29
 
 - **Precision code intelligence now ships in the base install.** `find_refs` /

--- a/README.md
+++ b/README.md
@@ -103,6 +103,21 @@ uv run chad "add a --json flag to main.py and update the tests"   # one-shot, he
 uv run chad -c               # resume this directory's last conversation
 ```
 
+**Optional extras.** Everything core is in the base install; two features are opt-in
+because they pull deps not every install wants — `speech` (voice mode: a mic library,
+no torch) and `highlight` (syntax colour in diffs/previews). An extra rides on the
+**install spec**, not on a separate command, so how you add it depends on how you
+installed chad:
+
+```bash
+uv tool install --force 'chad-code[speech]'   # add to an existing `uv tool` install
+uvx --from 'chad-code[speech]' chad           # one-off run, nothing installed
+uv sync --extra speech                        # from a clone
+```
+
+`/speech` in the TUI prints whichever of those matches your install, so you never have
+to work it out from here.
+
 **The model.** chad picks one for you by RAM and downloads it once into the shared Hugging
 Face cache (`~/.cache/huggingface`, reused across every project). Override with
 `--model 9b` / `--model 35b`, or `--model <repo or local dir>` for anything else.
@@ -128,8 +143,8 @@ re-downloads the model.
 **Development.** `uv sync` once, then `uv run pytest -q` — the fast unit gate loads **no
 model weights**, runs in seconds, and is what CI runs. Throughput on your own machine:
 `uv run chad-bench` (see [Throughput & performance](docs/benchmarks.md)). LSP-precise
-find-references / rename need the `lsp` extra (`uv tool install 'chad-code[lsp]'`); without
-it chad uses the tree-sitter fallback automatically.
+find-references / rename need no extra — chad fetches pyright via `uvx` on first use and
+falls back to tree-sitter when a language server can't start.
 
 ## Interactive UX
 
@@ -155,8 +170,9 @@ it chad uses the tree-sitter fallback automatically.
   isn't clipped, and a personal word table (`~/.chad/speech_words.json`) teaches it your
   identifiers — `{"pie test": "pytest"}`. Dictation cost is linear in take length, so a
   long thought is fine; `/speech` off releases both the mic and the weights. Nothing
-  leaves the machine. Needs the `speech` extra (`uv sync --extra speech` — just a mic
-  library; no torch, no numba).
+  leaves the machine. Needs the `speech` extra — just a mic library; no torch, no numba
+  (see [Installing & upgrading](#installing--upgrading); on a `uv tool` install that's
+  `uv tool install --force 'chad-code[speech]'`).
 
 **Usage.** `uv run chad --help` is the source of truth:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # import name, and command name are independent. `uvx chad-code` runs the alias
 # script added under [project.scripts].
 name = "chad-code"
-version = "1.0.7"
+version = "1.0.8"
 description = "Local MLX-backed, Claude-Code-style coding agent (Apple Silicon, Ornith 35B/9B)"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,15 @@ dependencies = [
     "mcp>=2,<3",
 ]
 
+# Extras ride on the INSTALL SPEC, so the command depends on how chad was installed:
+# `uv tool install --force 'chad-code[<extra>]'` (or `uvx --from 'chad-code[<extra>]' chad`)
+# for a PyPI install, `uv sync --extra <extra>` only in a clone. speech.install_hint()
+# derives the right one at runtime — keep it in step with any extra added here.
+# NOTE: the PyPI distribution is `chad-code`; 'pip install chad' installs an unrelated
+# squatted package.
+#
 # Optional syntax highlighting in diffs / confirm previews. Pure-Python,
 # import-guarded in render.py: absent, output is byte-identical to the un-highlighted path.
-# Install with `uv sync --extra highlight`.
-# NOTE: no PyPI release exists; 'pip install chad' installs an unrelated squatted
-# package. Document uv/git installs only.
 [project.optional-dependencies]
 highlight = ["pygments>=2.17"]
 # Voice mode (/speech in the TUI): push-to-talk dictation via chad's vendored
@@ -85,7 +89,7 @@ highlight = ["pygments>=2.17"]
 # `say`. All on-device, nothing leaves the machine. mlx/numpy/huggingface-hub
 # are already core deps, so the extra adds only the mic (sounddevice/PortAudio).
 # Optional and import-guarded in speech.py: absent, /speech prints the install
-# hint and everything else is untouched. Install with `uv sync --extra speech`.
+# hint and everything else is untouched.
 speech = [
     "sounddevice>=0.5",
 ]

--- a/src/chad/__init__.py
+++ b/src/chad/__init__.py
@@ -4,7 +4,7 @@ A flat collection of cooperating modules behind one console script (``chad``):
 the inference engine, the tool layer, the agent loop, and the terminal UI.
 """
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 
 # chad sets no MLX_* runtime vars. MLX_METAL_FAST_SYNCH, MLX_MAX_OPS_PER_BUFFER
 # and MLX_MAX_MB_PER_BUFFER were each measured end-to-end on the 35B and every

--- a/src/chad/speech.py
+++ b/src/chad/speech.py
@@ -85,6 +85,27 @@ def model_cached() -> bool:
         return False
 
 
+def install_hint(extra: str = "speech", path: str | None = None) -> str:
+    """The command that adds an optional extra to THIS install.
+
+    There is no single right answer: an extra attaches to the install SPEC for a
+    `uv tool`/`uvx` install and to `uv sync` only in a clone, so the one-line
+    hint /speech prints has to know which of those it's talking to — a clone-only
+    hint sends the (majority) PyPI user to a command that can't work. Keyed off
+    where this file physically lives, the one thing we can observe.
+    """
+    here = os.path.realpath(path or __file__)
+    if f"{os.sep}uv{os.sep}tools{os.sep}" in here:   # uv tool install
+        return f"uv tool install --force 'chad-code[{extra}]'"
+    # uvx's ephemeral env: hardlinked out of the uv cache (archive-v*/environments-v*).
+    if f"{os.sep}uv{os.sep}archive-" in here or f"{os.sep}uv{os.sep}environments-" in here:
+        return f"uvx --from 'chad-code[{extra}]' chad"
+    root = os.path.dirname(os.path.dirname(os.path.dirname(here)))  # src/chad/x.py -> repo
+    if os.path.exists(os.path.join(root, "pyproject.toml")):
+        return f"uv sync --extra {extra}"
+    return f"uv pip install 'chad-code[{extra}]'"    # a plain venv
+
+
 def available():
     """(ok, reason). ok=False carries the one-line reason speech can't start —
     surfaced verbatim by /speech, so it names the fix, not just the failure."""
@@ -102,7 +123,7 @@ def available():
         missing.append("sounddevice")
     if missing:
         return False, (f"speech needs {' + '.join(missing)} — install with "
-                       f"`uv sync --extra speech` (all local: Parakeet-on-MLX STT, "
+                       f"`{install_hint()}` (all local: Parakeet-on-MLX STT, "
                        f"macOS `say` TTS)")
     return True, ""
 

--- a/tests/test_speech.py
+++ b/tests/test_speech.py
@@ -110,7 +110,24 @@ def test_available_reports_missing_deps_as_hint():
     ok, reason = speech.available()
     assert ok in (True, False)
     if not ok:
-        assert "uv sync --extra speech" in reason
+        assert "sounddevice" in reason and "speech" in reason
+
+
+def test_install_hint_matches_how_chad_was_installed():
+    # The hint is the whole fix, so it has to name the command that works for the
+    # reader: extras ride on the install spec for uvx/tool installs, on `uv sync`
+    # only in a clone. Paths are the real shapes uv produces.
+    h = speech.install_hint
+    assert h(path="/Users/x/.local/share/uv/tools/chad-code/lib/python3.13/"
+                  "site-packages/chad/speech.py") == \
+        "uv tool install --force 'chad-code[speech]'"
+    assert h(path="/Users/x/.cache/uv/archive-v0/abc123/lib/python3.13/"
+                  "site-packages/chad/speech.py") == "uvx --from 'chad-code[speech]' chad"
+    assert h(path="/Users/x/.local/share/uv/python/venv/lib/python3.13/"
+                  "site-packages/chad/speech.py") == "uv pip install 'chad-code[speech]'"
+    # This test file IS a clone, so the live module resolves to the clone form.
+    assert speech.install_hint() == "uv sync --extra speech"
+    assert h("highlight") == "uv sync --extra highlight"
 
 
 def test_collapse_repeats_kills_hallucination_loop():

--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,7 @@ wheels = [
 
 [[package]]
 name = "chad-code"
-version = "1.0.7"
+version = "1.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },


### PR DESCRIPTION
- **`/speech` now names an install command that can actually work.** The voice-mode
  install hint was hardcoded to `uv sync --extra speech` — true only in a git clone, so
  every published install (`uvx chad-code`, `uv tool install chad-code`) was sent to a
  command with no project to sync. An extra rides on the *install spec*, not on a
  separate step, and `speech.install_hint()` now derives the right form from how chad was
  actually installed: `uv tool install --force 'chad-code[speech]'`, `uvx --from
  'chad-code[speech]' chad`, `uv sync --extra speech` in a clone, or `uv pip install
  'chad-code[speech]'` in a plain venv.
- **Extras documented in one place.** The README install section now states the
  install-spec rule with all three commands side by side, so the PyPI project page
  carries it too. Also drops a stale line claiming LSP-precise find-refs/rename need an
  `lsp` extra — that extra is gone and precision ships in the base install as of 1.0.7.
