### PR TITLE
release 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 Notable, user-visible changes.
 
+## [1.11.0] — 2026-08-06
+
+- **New tool: `definition(name)`** — jump from a *use* of a symbol to the one
+  place it is really defined, following imports and aliases through the language
+  server (pyright/TS/gopls/rust-analyzer/clangd/…), with the honestly-labeled
+  tree-sitter name-match as fallback. The capability had existed since 1.0.7;
+  no tool schema exposed it — the model could never call it. Asked at a use
+  site, not the definition (asking at the definition answers with itself), so
+  two files defining `target` resolve to the one your file actually imports.
+  Verified across 13 fixture languages.
+- **Three new "ambient state" levers (default OFF, like everything since
+  1.10.0): the harness states facts in the results the model already reads,
+  instead of steering it toward tools it demonstrably won't call.** Trace
+  measurement over ~140k tool calls showed the model routes ~83% of its
+  searching through `bash` and calls the symbolic tools ~never, under a prompt
+  that already says not to — so these meet it on the route it chose:
+  - `env_manifest` — a session-start toolchain inventory in the system prompt
+    (compilers/interpreters with versions, notable absences, package managers;
+    ~75 tokens, built once in <1s, prefix-resident). Answers the
+    `which`/`--version`/`pip list` probe chains up front — measured at 3.3
+    probes per failing trial, 37% of them failing.
+  - `session_ledger` — one cumulative fact line on landed edits and done
+    bounces: `[session] edited: x.py·parse() · wrote: answer.txt · last
+    verifying run: 2 calls ago (pytest → exit 1)`. Facts with provenance,
+    never instructions; revert-aware; elided when unchanged. Aimed at the
+    largest measured failure class — confident `done`s built on a stale
+    mental model of what changed and what was actually re-run.
+  - `bash_read_skeleton` — the first time a source file's content comes back
+    through `cat`/`sed`/`read`, the result carries a one-line symbol map
+    (`[file] mod.py: alpha() 1-2 · Gamma 9-11`); a zero-hit `grep` for a
+    symbol the tags cache knows gets its real definition site. Symbol
+    intelligence with no new tool name to learn.
+
+  Enable with `CHAD_ENABLE=env_manifest,session_ledger,bash_read_skeleton` (or
+  `all`); each is instrumented (`fired()` telemetry) and A/B-able on its own.
+
 ## [1.10.0] — 2026-08-05
 
 - **Every harness lever now defaults OFF: a default run is the bare model + tool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # import name, and command name are independent. `uvx chad-code` runs the alias
 # script added under [project.scripts].
 name = "chad-code"
-version = "1.10.0"
+version = "1.11.0"
 description = "Local MLX-backed, Claude-Code-style coding agent (Apple Silicon, Ornith 35B/9B)"
 readme = "README.md"
 license = "MIT"

--- a/src/chad/__init__.py
+++ b/src/chad/__init__.py
@@ -4,7 +4,7 @@ A flat collection of cooperating modules behind one console script (``chad``):
 the inference engine, the tool layer, the agent loop, and the terminal UI.
 """
 
-__version__ = "1.0.9"
+__version__ = "1.11.0"
 
 # chad sets no MLX_* runtime vars. MLX_METAL_FAST_SYNCH, MLX_MAX_OPS_PER_BUFFER
 # and MLX_MAX_MB_PER_BUFFER were each measured end-to-end on the 35B and every

--- a/src/chad/agent.py
+++ b/src/chad/agent.py
@@ -14,7 +14,7 @@ import re
 import sys
 import time
 
-from . import atif, compaction, config, guardrails, levers, session, syntaxgate
+from . import ambient, atif, compaction, config, guardrails, levers, session, syntaxgate
 from .base_engine import BackendError, BaseEngine
 from .diag import args_preview, log, redact, result_preview
 from .prompt import build_subagent_prompt, build_system_prompt, classify_intent
@@ -47,7 +47,7 @@ SUBAGENT_MAX_STEPS = 24
 SUBAGENT_CTX_LIMIT = 32000
 SUBAGENT_READ_ONLY = {
     "read", "grep", "glob", "repo_map", "overview", "view_symbol",
-    "find_symbol", "find_refs", "done", "finish", "stop",
+    "find_symbol", "definition", "find_refs", "done", "finish", "stop",
 }
 # `write_todos` is deliberately absent: a sub-agent that plans its own work would mutate
 # the process-global `_TODOS` and clobber the parent's pinned todo panel (and `_sub_emit`
@@ -346,6 +346,8 @@ class Agent:
             skills.reset_session()
             from . import mcp
             mcp.reset_session()
+            ambient.reset()  # fresh session-state ledger; sub-agents share the
+                             # parent's and never feed it (see run_turn)
         self.mode = mode or ("yolo" if yolo else "normal")
         self.thinking = thinking  # Ornith is a reasoning model; toggles <think> blocks
         # Steps per WINDOW, not a hard kill: a window that landed+verified a change
@@ -1696,10 +1698,15 @@ class Agent:
                     log.info("DONE rejected: edits not verified -> nudge #%d", verify_nudges)
                     self.messages.append({
                         "role": "tool", "name": "done",
+                        # The session-ledger facts (what changed, what last ran) ride
+                        # the bounce when the lever is on — the model's stale state
+                        # model IS the wrong-verify bug.
                         "content": "[not done yet: you changed files but have not run anything "
                                    "to verify them. Run the project's tests (or the code) with "
                                    "bash, check the output is correct, then call done. If a test "
-                                   "fails, fix the code first.]",
+                                   "fails, fix the code first.]"
+                                   + ("" if self._subagent else
+                                      ambient.ledger_suffix(step=step, force=True)),
                     })
                     continue
                 if action_task and not read_only_intent and self.mode != "plan" \
@@ -1793,8 +1800,11 @@ class Agent:
                                        if self._turn_budget_s else float("inf"))
                             log.info("DONE-AUDIT bounce: paths=%s runway=%.0fs",
                                      guardrails.audit_extract_paths(audit_task), _runway)
-                            self.messages.append({"role": "tool", "name": "done",
-                                                  "content": audit})
+                            self.messages.append({
+                                "role": "tool", "name": "done",
+                                # Session-ledger facts ride the audit bounce
+                                "content": audit
+                                + ambient.ledger_suffix(step=step, force=True)})
                             continue
                     # Absent-path re-bounce (see the final-answer twin above): a
                     # still-absent task-named path at accept time gets ONE more bounce,
@@ -1981,6 +1991,16 @@ class Agent:
                         log.info("TOOL %s duplicate result elided (%d chars)",
                                  name, len(result))
                         result = _elided
+                    # Ambient state: fold this result into the session
+                    # ledger and append whatever fact lines the enabled levers owe it
+                    # (session_ledger on landed mutations, bash_read_skeleton on file
+                    # content surfacing through bash/read). After the clip cap on
+                    # purpose — a clipped result must still carry its facts; the
+                    # appended text is bounded in ambient.py. Main agent only: a
+                    # sub-agent's transcript folds away and must not pollute the
+                    # parent's ledger.
+                    if not self._subagent:
+                        result = ambient.annotate(name, args, result, step=step)
                     step_tool_chars += len(result)
                     if _PREFILL_TRACE:
                         self._trace_tools_pending.append([name, round(_tool_s, 4)])

--- a/src/chad/ambient.py
+++ b/src/chad/ambient.py
@@ -1,0 +1,453 @@
+"""Ambient state for the result channel.
+
+Trace measurement showed the model routes ~83% of its searching through `bash` and
+calls the symbolic tools ~never, under a system prompt that already tells it not
+to — routing follows the model's trained prior, and steering text does not move
+it. The inversion implemented here: leave the model on the route it chose and
+make the harness's knowledge ambient IN that route — facts appended to results
+the model already reads, never a new tool, never an admonition, never a blocked
+command.
+
+Three levers, all default OFF (the 1.10.0 contract), each with its own
+trace-measured target:
+
+  env_manifest        session-start toolchain/package inventory in the system
+                      prompt tail. Target: the environment-probe class
+                      (which/--version/pip list…), measured fail-enriched at
+                      3.33/trial in fails vs 2.46 in passes, 37% failing.
+  session_ledger      one cumulative fact line — what changed, what was created,
+                      when something was last actually run — appended to landed
+                      mutation results and to done bounces. Target: the
+                      wrong-verify/confident-wrong-done class (the #1 measured
+                      fail bucket) read as a state-visibility gap, plus blind
+                      re-reads (21.8% of reads; fail 1.20 vs pass 0.86/trial).
+  bash_read_skeleton  a one-line symbol map appended the first time a source
+                      file's content comes back through bash cat/sed/head or
+                      `read`, and a definition pointer when a bash grep for a
+                      known symbol comes back empty. Target: blind re-reads and
+                      the product story (structure ambient in the channel a
+                      shell-native model actually uses).
+
+STATE is module-global and session-scoped, like tools._FILE_SEEN: one chad
+process is one session. `Agent.__init__` resets it for a fresh main agent;
+sub-agents never feed it (they are read-only and their transcript folds away).
+Bookkeeping runs even while the levers are OFF — the eval harness flips
+CHAD_ENABLE between tasks in-process, and a lever enabled mid-session must see
+true state, not state that started when it did. With every lever OFF the
+annotate path returns its input byte-identically.
+
+The confabulation rule: every line states observable facts in
+past tense with its provenance ("last verifying run: …"), never an instruction
+and never a claim about correctness — a ledger line must not be quotable as
+verification the model didn't perform.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import shutil
+import subprocess
+
+from . import levers
+
+# Appended ambient text is bounded so it can never bloat a result the clip cap
+# already sized (annotation happens after _clip_tool_result on purpose — a
+# clipped result must still carry its facts).
+_LEDGER_MAX = 300
+_SKELETON_MAX = 220
+_SKELETON_MIN_DEFS = 3     # a 2-symbol file's structure is visible at a glance
+_MANIFEST_PROBE_TIMEOUT = 1.5
+_MANIFEST_MAX_VERSIONS = 16
+
+# ---------------------------------------------------------------------------
+# session state
+# ---------------------------------------------------------------------------
+
+_calls = 0                       # tool results seen (main agent)
+_edited: dict[str, set] = {}     # rel path -> symbol names (empty set = file-level)
+_wrote: list = []                # rel paths written whole (order kept, deduped)
+_last_run: dict | None = None    # {"call": int, "head": str, "exit": int}
+_last_ledger_key: str = ""       # dedup key of the last emitted ledger line
+_skeleton_shown: set = set()     # abs paths whose skeleton line already rode a result
+_manifest_cache: str | None = None
+
+
+def reset() -> None:
+    """Fresh session (a new main Agent). Clears all ambient bookkeeping."""
+    global _calls, _last_run, _last_ledger_key, _manifest_cache
+    _calls = 0
+    _edited.clear()
+    _wrote.clear()
+    _last_run = None
+    _last_ledger_key = ""
+    _skeleton_shown.clear()
+    _manifest_cache = None
+
+
+# ---------------------------------------------------------------------------
+# bookkeeping (always on — see module docstring)
+# ---------------------------------------------------------------------------
+
+_ERROR_SENTINELS = ("[exit", "[timed out", "[interrupted", "[failed to launch")
+_EXIT_RE = re.compile(r"^\[exit (-?\d+)\]")
+_EDIT_TOOLS = ("edit", "replace_lines", "insert_lines")
+_SYMBOL_EDIT_PREFIX = {"replace_symbol": "[replaced", "insert_symbol": "[inserted",
+                       "rename_symbol": "[renamed"}
+
+
+def _rel(path: str) -> str:
+    try:
+        rel = os.path.relpath(path)
+    except ValueError:
+        return path
+    return path if rel.startswith("..") else rel
+
+
+# Project-runner wrappers that carry the real program as their argument. Stripped
+# before the executing/trivial checks so `uv run pytest` records a pytest run —
+# ambient-only normalization; the verify gate's own regex is deliberately untouched
+# (changing what disarms the unverified-edit flag is a different, riskier change).
+_RUNNER_WRAPPER_RE = re.compile(
+    r"\b(?:uv|poetry|pipenv|pdm|hatch)\s+run\s+(?:python[0-9.]*\s+-m\s+)?")
+
+
+def _cmd_head(command: str) -> str:
+    """The program the verifying run actually invoked, for the ledger's provenance
+    note — derived from the same regex the verify gate uses, so the two never
+    disagree about what counts as executing."""
+    from . import guardrails
+    m = guardrails._EXECUTES_RE.search(command)
+    if not m:
+        return ""
+    return re.sub(r"^[^\w./]+", "", m.group(0)).strip()
+
+
+def _landed(name: str, result: str) -> bool:
+    if name == "write":
+        return result.startswith("[wrote")
+    if name in _EDIT_TOOLS:
+        return result.startswith("[edited")
+    prefix = _SYMBOL_EDIT_PREFIX.get(name)
+    return prefix is not None and result.startswith(prefix)
+
+
+def note_call(name: str, args: dict, result: str) -> None:
+    """Fold one tool result into the session state. Facts only — no lever gates
+    here, so state is true whenever a lever consults it."""
+    global _calls, _last_run
+    _calls += 1
+    if _landed(name, result):
+        path = str(args.get("path", "") or "")
+        if name == "write":
+            rel = _rel(path)
+            if rel and rel not in _wrote:
+                _wrote.append(rel)
+            _edited.pop(rel, None)  # a whole-file write supersedes prior edit facts
+        else:
+            sym = str(args.get("name", "") or "")  # symbolic edits carry the symbol
+            rel = _rel(path) if path else ""
+            if not rel and sym:
+                rel = "?"  # symbol edit resolved by name alone; file unknown here
+            if rel:
+                _edited.setdefault(rel, set())
+                if sym:
+                    _edited[rel].add(sym)
+        return
+    if name == "bash":
+        from . import guardrails
+        cmd = str(args.get("command", "") or "")
+        if not cmd:
+            return
+        if guardrails.reverts_working_tree(cmd) and not result.startswith(_ERROR_SENTINELS):
+            # The tree was discarded: earlier edit facts are no longer true state.
+            _edited.clear()
+            _wrote.clear()
+            return
+        if result.startswith(("[timed out", "[interrupted", "[failed to launch")):
+            return
+        bare = _RUNNER_WRAPPER_RE.sub("", cmd)
+        if guardrails._is_trivial_check(bare) or not guardrails._is_executing_command(bare):
+            return
+        m = _EXIT_RE.match(result)
+        _last_run = {"call": _calls, "head": _cmd_head(bare) or "bash",
+                     "exit": int(m.group(1)) if m else 0}
+
+
+# ---------------------------------------------------------------------------
+# E2 — session ledger
+# ---------------------------------------------------------------------------
+
+def _ledger_body() -> tuple[str, str]:
+    """(line, dedup_key). The dedup key excludes the calls-ago counter, so an
+    unchanged state is elided even though the counter ticks."""
+    parts = []
+    if _edited:
+        ent = []
+        for rel, syms in list(_edited.items())[:6]:
+            shown = sorted(syms)[:2]
+            ent.append(rel + ("·" + ",".join(f"{s}()" for s in shown) if shown else ""))
+        if len(_edited) > 6:
+            ent.append(f"+{len(_edited) - 6} more")
+        parts.append("edited: " + ", ".join(ent))
+    if _wrote:
+        shown = _wrote[:4]
+        more = f" +{len(_wrote) - 4} more" if len(_wrote) > 4 else ""
+        parts.append("wrote: " + ", ".join(shown) + more)
+    if not parts:
+        return "", ""
+    if _last_run is None:
+        run = "no verifying run yet"
+        key_run = run
+    else:
+        ago = _calls - _last_run["call"]
+        status = "exit 0" if _last_run["exit"] == 0 else f"exit {_last_run['exit']}"
+        ago_txt = "this call" if ago == 0 else f"{ago} call{'s' if ago > 1 else ''} ago"
+        run = f"last verifying run: {ago_txt} ({_last_run['head']} → {status})"
+        key_run = f"run@{_last_run['call']}:{status}"
+    line = " · ".join(parts + [run])
+    if len(line) > _LEDGER_MAX:
+        line = line[: _LEDGER_MAX - 1] + "…"
+    return line, " · ".join(parts) + "|" + key_run
+
+
+def ledger_suffix(step: int | None = None, force: bool = False) -> str:
+    """The `[session]` fact line to append, or "". Emits only when the lever is
+    on and the state changed since the last emission (`force` bypasses the dedup
+    for done-time bounces, where restating current facts is the point)."""
+    global _last_ledger_key
+    if not levers.enabled("session_ledger"):
+        return ""
+    line, key = _ledger_body()
+    if not line:
+        return ""
+    if not force and key == _last_ledger_key:
+        return ""
+    _last_ledger_key = key
+    levers.fired("session_ledger", step=step)
+    return f"\n[session] {line}"
+
+
+# ---------------------------------------------------------------------------
+# E3 — skeleton / definition pointer on the bash route
+# ---------------------------------------------------------------------------
+
+_BASH_OPEN_RE = re.compile(
+    r"(?:^|[|;&]|\$\()\s*(?:sudo\s+)?(?:cat|head|tail|nl|less|more|sed)\b")
+_BASH_GREP_RE = re.compile(r"(?:^|[|;&]|\$\()\s*(?:sudo\s+)?(?:grep|rg|ag)\b")
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{2,}$")
+_PATHISH_RE = re.compile(r"^[\w./+-]+\.[A-Za-z0-9]{1,6}$")
+_GREP_SKIP_ARG = frozenset(("-e", "-A", "-B", "-C", "-m", "-g", "-t",
+                            "--include", "--exclude", "--exclude-dir", "--glob",
+                            "--type"))
+
+
+def _shell_tokens(command: str) -> list:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
+
+
+def _opened_paths(command: str) -> list:
+    """Existing file paths a display command (cat/head/sed …) put on screen."""
+    if not _BASH_OPEN_RE.search(command):
+        return []
+    return [t for t in _shell_tokens(command)
+            if _PATHISH_RE.match(t) and os.path.isfile(t)]
+
+
+def _grep_ident(command: str) -> str:
+    """The identifier a bash grep searched for, or "". First non-flag argument
+    of the first grep/rg/ag segment, identifier-shaped only."""
+    m = _BASH_GREP_RE.search(command)
+    if not m:
+        return ""
+    tail = command[m.start():]
+    for cut in ("|", ";", "&&"):
+        i = tail.find(cut, 1)
+        if i > 0:
+            tail = tail[:i]
+    toks = _shell_tokens(tail)
+    skip = False
+    for t in toks[1:]:
+        if skip:
+            skip = False
+            continue
+        if t.startswith("-"):
+            skip = t in _GREP_SKIP_ARG and "=" not in t
+            continue
+        t = t.strip("'\"")
+        return t if _IDENT_RE.match(t) else ""
+    return ""
+
+
+def _skeleton_line(path: str) -> str:
+    """`[file] rel: sym 12-88 · …` from the cached tags, top-level symbols only,
+    or "". Never parses fresh beyond what the mtime cache already does."""
+    from . import repomap
+    svc = repomap.service()
+    if not svc.lang_for(path):
+        return ""
+    try:
+        defs, _ = svc._extract(os.path.abspath(path))
+    except Exception:  # noqa: BLE001 - structure is best-effort decoration
+        return ""
+    top = [d for d in defs if not d.scope]
+    if len(top) < _SKELETON_MIN_DEFS:
+        return ""
+    ent = []
+    for d in top:
+        mark = "()" if d.kind in ("function", "method") else ""
+        ent.append(f"{d.name}{mark} {d.line}-{d.end_line}")
+    line = f"[file] {_rel(path)}: " + " · ".join(ent)
+    if len(line) > _SKELETON_MAX:
+        line = line[: _SKELETON_MAX - 1] + "…"
+    return line
+
+
+def _def_pointer(ident: str) -> str:
+    """`[file] 'x' is defined at rel:line` when a zero-hit grep named a symbol
+    the tags cache knows — the definition answer delivered on the bash route."""
+    from . import repomap
+    try:
+        hits = repomap.service()._find_defs(ident)
+    except Exception:  # noqa: BLE001
+        return ""
+    if not hits or len(hits) > 3:  # a pile of same-named defs is not an answer
+        return ""
+    where = " · ".join(f"{d.rel}:{d.line}" for d in hits)
+    return f"[file] no match, but `{ident}` is defined at {where}"
+
+
+def _skeleton_suffix(name: str, args: dict, result: str, step=None) -> str:
+    if not levers.enabled("bash_read_skeleton"):
+        return ""
+    candidates: list = []
+    zero_hit_ident = ""
+    if name == "read":
+        # Skip error sentinels and the big-file structure view (already a skeleton)
+        # and the paging lead (its nudge covers structure).
+        if not result.startswith("["):
+            p = str(args.get("path", "") or "")
+            if p and os.path.isfile(p):
+                candidates.append(p)
+    elif name == "bash":
+        cmd = str(args.get("command", "") or "")
+        if not result.startswith(("[timed out", "[interrupted", "[failed to launch")):
+            candidates.extend(_opened_paths(cmd)[:2])
+        if result == "[no output]" or result.startswith("[exit 1]"):
+            zero_hit_ident = _grep_ident(cmd)
+    out = []
+    for p in candidates[:2]:
+        ap = os.path.abspath(p)
+        if ap in _skeleton_shown:
+            continue
+        line = _skeleton_line(p)
+        if line:
+            _skeleton_shown.add(ap)
+            levers.fired("bash_read_skeleton", step=step, kind="skeleton")
+            out.append(line)
+    if zero_hit_ident:
+        line = _def_pointer(zero_hit_ident)
+        if line:
+            levers.fired("bash_read_skeleton", step=step, kind="defsite")
+            out.append(line)
+    return ("\n" + "\n".join(out)) if out else ""
+
+
+# ---------------------------------------------------------------------------
+# the one agent-facing hook
+# ---------------------------------------------------------------------------
+
+def annotate(name: str, args: dict, result: str, step: int | None = None) -> str:
+    """Fold this result into session state, then append whatever ambient lines
+    the enabled levers owe it. With every lever OFF, returns `result` unchanged
+    (byte-identical) — the bookkeeping still runs so a lever enabled mid-session
+    sees true state."""
+    landed = _landed(name, result)
+    note_call(name, args, result)
+    suffix = ""
+    if landed:
+        suffix += ledger_suffix(step=step)
+    suffix += _skeleton_suffix(name, args, result, step=step)
+    return result + suffix
+
+
+# ---------------------------------------------------------------------------
+# E1 — environment manifest
+# ---------------------------------------------------------------------------
+
+# What the traces show being probed. Version flags where a tool deviates from
+# `--version`; absences reported only for the commonly-probed set (an exhaustive
+# absence list would be noise). Alias families (python3/python, pip/pip3) count
+# as absent only when the WHOLE family is missing — "NOT installed: pip" next to
+# a present pip3 would be a lie.
+_MANIFEST_TOOLS = (
+    "python3", "python", "pip", "pip3", "gcc", "g++", "clang", "make", "cmake",
+    "git", "node", "npm", "cargo", "rustc", "go", "java", "javac", "docker",
+    "ruby", "perl", "pytest", "uv",
+)
+_VERSION_ARGS = {"go": ("version",), "java": ("-version",), "javac": ("-version",)}
+_NOTABLE_ABSENT = ("python3", "pip", "gcc", "g++", "make", "cmake", "node",
+                   "npm", "cargo", "go", "java", "docker")
+_ALIAS_FAMILY = {"python3": ("python3", "python"), "pip": ("pip", "pip3")}
+_PKG_MANAGERS = ("apt-get", "dnf", "yum", "apk", "brew", "pacman")
+_VERSION_NUM_RE = re.compile(r"\d+\.\d+[\w.\-]*")
+
+
+def _probe_version(tool: str) -> str:
+    args = _VERSION_ARGS.get(tool, ("--version",))
+    try:
+        p = subprocess.run((tool,) + args, capture_output=True, text=True,
+                           errors="replace", timeout=_MANIFEST_PROBE_TIMEOUT)
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    first = ((p.stdout or "") + (p.stderr or "")).strip().splitlines()
+    if not first:
+        return ""
+    m = _VERSION_NUM_RE.search(first[0])
+    return m.group(0) if m else first[0][:24]
+
+
+def _build_manifest() -> str:
+    have = {t for t in _MANIFEST_TOOLS if shutil.which(t)}
+    present = [t for t in _MANIFEST_TOOLS if t in have]
+    absent = [t for t in _NOTABLE_ABSENT
+              if not any(a in have for a in _ALIAS_FAMILY.get(t, (t,)))]
+    lines = []
+    if present:
+        # Probes run concurrently — they are subprocess-spawn bound, and serially
+        # a full toolchain costs ~4s of session startup (measured); parallel is
+        # ~the slowest single probe.
+        from concurrent.futures import ThreadPoolExecutor
+        to_probe = present[:_MANIFEST_MAX_VERSIONS]
+        with ThreadPoolExecutor(max_workers=8) as ex:
+            versions = list(ex.map(_probe_version, to_probe))
+        versioned = [f"{t} {v}" if v else t for t, v in zip(to_probe, versions)]
+        versioned.extend(present[_MANIFEST_MAX_VERSIONS:])
+        lines.append("- present: " + " · ".join(versioned))
+    if absent:
+        lines.append("- NOT installed: " + ", ".join(absent))
+    pkgs = [p for p in _PKG_MANAGERS if shutil.which(p)]
+    if pkgs or "pip" in have or "pip3" in have:
+        pip = ["pip"] if ("pip" in have or "pip3" in have) else []
+        lines.append("- package managers: " + ", ".join(pkgs + pip))
+    return "\n".join(lines)
+
+
+def env_manifest() -> str:
+    """The manifest block body, built once per session (subprocess probes are not
+    free) and never rebuilt — installs after session start are deliberately not
+    reflected; the header text says so. "" when the lever is off or nothing was
+    detected."""
+    global _manifest_cache
+    if not levers.enabled("env_manifest"):
+        return ""
+    if _manifest_cache is None:
+        try:
+            _manifest_cache = _build_manifest()
+        except Exception:  # noqa: BLE001 - orientation is best-effort, never fatal
+            _manifest_cache = ""
+    return _manifest_cache

--- a/src/chad/guardrails.py
+++ b/src/chad/guardrails.py
@@ -196,7 +196,8 @@ def bash_result_verifies(result: str, command: str = "") -> bool:
 # tools, but NOT planning/done. Kept as a named constant so the set is testable.
 SUBSTANTIVE_TOOLS = ("grep", "glob", "read", "write", "edit", "bash",
                      "repo_map", "overview", "view_symbol", "find_symbol",
-                     "find_refs", "replace_symbol", "insert_symbol", "rename_symbol")
+                     "definition", "find_refs", "replace_symbol", "insert_symbol",
+                     "rename_symbol")
 
 
 # Working-tree DISCARD commands: after one of these runs cleanly, the edits the model
@@ -1124,8 +1125,8 @@ _EDIT_TOOLS = ("write", "edit", "replace_symbol", "insert_symbol", "rename_symbo
 # Read/search tools whose target the note records as "already examined" so a relaunch
 # doesn't re-walk the tree it already mapped (the demonstrated leak: repeated attempts
 # burned their whole budget re-exploring because the note carried only edited files).
-_READ_TOOLS = ("read", "grep", "glob", "view_symbol", "find_symbol", "find_refs",
-               "repo_map", "overview")
+_READ_TOOLS = ("read", "grep", "glob", "view_symbol", "find_symbol", "definition",
+               "find_refs", "repo_map", "overview")
 _ERROR_PREFIXES = ("[exit", "[timed out", "[failed to launch", "[tool error", "[denied")
 # Lines in a tool result worth carrying as the failing-test signature — the concrete
 # assertion/exception the next attempt must make pass, not just "[exit 1]".
@@ -1547,7 +1548,7 @@ DUP_ELIDE_MIN_CHARS = 400  # below this the pointer saves nothing over the body
 # have their own guard); MCP tools are excluded (openWorld results may legitimately
 # repeat, e.g. polling).
 DUP_ELIDABLE = {"read", "grep", "glob", "repo_map", "overview", "view_symbol",
-                "find_symbol", "find_refs"}
+                "find_symbol", "definition", "find_refs"}
 
 
 def elide_duplicate_result(name, result, messages):

--- a/src/chad/levers.py
+++ b/src/chad/levers.py
@@ -471,6 +471,39 @@ LEVERS: dict[str, Lever] = {
         "call. Degrades to the flat listing when repomap is unavailable (see prompt.py).",
         "ai-codex", fires=PASSIVE),
 
+    # --- group "ambient": facts in the result channel. Trace measurement showed the
+    #     model routes ~83% of searching through bash and ignores the symbolic tools
+    #     under maximal prompt steering; these levers stop asking it to change routes
+    #     and put the harness's state knowledge in the results it already reads.
+    #     Facts only, never admonitions — the clean-slate arms priced the admonition
+    #     class at ~0.
+    "env_manifest": Lever(
+        "Append a session-start environment manifest (toolchains present with "
+        "versions, notable absences, package managers) to the system-prompt tail, "
+        "answering the which/--version/pip-list probe class up front. Measured "
+        "fail-enriched: 3.33 probes/trial in fails vs 2.46 in passes, 37% of probes "
+        "failing outright. Stamped once at session start and never updated in place "
+        "(prefix-resident by design); post-install state is session_ledger's job.",
+        "ambient", fires=PASSIVE),
+    "session_ledger": Lever(
+        "Append one cumulative fact line to landed-mutation results and done bounces "
+        "— files edited (with symbols where known), files written, and when "
+        "something was last actually run (`last verifying run: N calls ago "
+        "(pytest → exit 1)`). State facts only, past tense, with provenance — never "
+        "an instruction, so it cannot be quoted as verification the model didn't "
+        "perform. Targets the wrong-verify done class (the #1 measured fail bucket) "
+        "as a state-visibility gap, and blind re-reads (21.8% of reads; fail 1.20 "
+        "vs pass 0.86/trial). Elided when state is unchanged since last emission.",
+        "ambient"),
+    "bash_read_skeleton": Lever(
+        "The first time a source file's content comes back through bash "
+        "cat/sed/head or `read`, append a one-line symbol map from the tags cache "
+        "(`[file] x.py: parse() 30-71 · _tune() 73-88`); when a bash grep for a "
+        "known symbol returns nothing, append its real definition site. Symbol "
+        "intelligence delivered on the route the model actually uses — it never "
+        "has to learn a tool name. Once per file per session.",
+        "ambient"),
+
     # --- group "ctxengine": the uniform-symbols work. -------------------------------
     "post_edit_diagnostics": Lever(
         "Append the language server's post-edit typecheck errors (~50 tokens, errors "

--- a/src/chad/prompt.py
+++ b/src/chad/prompt.py
@@ -68,6 +68,7 @@ structure and pull only what you need:
 - `overview(path)` — one file's functions/classes (signatures + line numbers) WITHOUT bodies. Do this before reading a file; only `view_symbol`/`read` the parts you need.
 - `view_symbol(name)` — read ONE function/class/method's source (name may be 'Class/method'). Use instead of `read` to inspect code.
 - `find_symbol(name)` — locate where something is DEFINED across the project (use instead of grep for definitions).
+- `definition(name)` — jump from a USE of a symbol to the ONE place it is really defined (follows imports and aliases; use when several things share a name and grep gives you a pile).
 - `find_refs(name)` — find every USE of a symbol across the project (use instead of grep for usages, e.g. before renaming/changing a function).
 - `replace_symbol(name, new)` — replace a whole function/class/method by name with new source (robust to whitespace; preferred over `edit` for rewriting a function). `insert_symbol(name, code, where)` adds code next to a symbol.
 - `rename_symbol(name, new_name)` — rename a symbol AND every reference to it across files in one step (precise: follows imports/scope, won't touch an unrelated same-named symbol). Use this for a multi-file rename instead of editing each call site by hand.
@@ -223,6 +224,12 @@ def _dynamic_context() -> list:
                 "\n# Workspace files (a real project — use grep/read to inspect before answering)\n"
                 + snapshot
             )
+    manifest = _env_manifest()
+    if manifest:
+        dynamic.append(
+            "\n# Environment manifest (detected at session start; later installs are "
+            "NOT reflected here)\n" + manifest
+        )
     test_cmd = _detect_test_command()
     if test_cmd:
         dynamic.append(
@@ -372,6 +379,19 @@ def _detect_test_command() -> str:
         except OSError:
             pass
     return ""
+
+
+def _env_manifest() -> str:
+    """The lever-gated (`env_manifest`) session-start toolchain inventory — the
+    environment analogue of the workspace map, answering the which/--version/pip-list
+    probe class before it is asked (probes measured fail-enriched 3.33 vs
+    2.46/trial). Built once per session in ambient.py, so the sub-agent prompt reuses
+    it without re-probing; "" (no block) when off or nothing detected."""
+    from . import ambient
+    try:
+        return ambient.env_manifest()
+    except Exception:  # noqa: BLE001 - orientation is best-effort; never block startup
+        return ""
 
 
 def _workspace_map(budget: int = 600) -> str:

--- a/src/chad/render.py
+++ b/src/chad/render.py
@@ -299,6 +299,8 @@ def render_tool_start(emit, name: str, args: dict):
         emit("tool", f"View {args.get('name', '')}")
     elif name == "find_symbol":
         emit("tool", f"Find {args.get('name', '')}")
+    elif name == "definition":
+        emit("tool", f"Def {args.get('name', '')}")
     elif name == "find_refs":
         emit("tool", f"Refs {args.get('name', '')}")
     elif name in ("replace_symbol", "insert_symbol"):
@@ -348,7 +350,7 @@ def render_tool_result(emit, name: str, args: dict, result: str):
     elif name == "overview":
         n = _nlines(result)
         emit("muted", f"  ⎿ {n} symbol{'s' * (n != 1)}")
-    elif name == "find_symbol":
+    elif name in ("find_symbol", "definition"):
         n = _nlines(result)
         emit("muted", f"  ⎿ {n} definition{'s' * (n != 1)}")
     elif name == "find_refs":

--- a/src/chad/repomap.py
+++ b/src/chad/repomap.py
@@ -29,6 +29,7 @@ import hashlib
 import logging
 import os
 import pickle
+import re
 import subprocess
 import sys
 import threading
@@ -825,6 +826,105 @@ class RepoMap:
             return f"[no definition found for '{name}']"
         out = [f"{h.rel}:{h.line}  {h.kind}  {h.sig}" for h in hits]
         return "\n".join(out[:100])
+
+    def _use_site(self, name: str, path=None, should_stop=None):
+        """A (rel, row0, col0) position where `name` is USED, or None.
+
+        `definition` needs a use site, not a definition site: asking the language
+        server go-to-definition at the definition itself answers with the
+        definition (or, for some servers, nothing). Cached reference Tags carry
+        (name, rel, line) but no column — tree-sitter's reference captures are
+        recorded per line — so the column is recovered by finding the identifier
+        as a whole word in that line's text. Prefers a use in `path` when given,
+        and never returns a line inside the symbol's own definition span (a
+        recursive call resolves to the def either way, but a same-file use
+        elsewhere is a better question to ask)."""
+        target = _qual_parts(name)[-1] if _qual_parts(name) else name
+        word = re.compile(rf"\b{re.escape(target)}\b")
+        files = ([os.path.join(self.root, path)] if path and not os.path.isabs(path)
+                 else ([path] if path else self._code_files(should_stop)))
+        if not path:
+            self._extract_all(files, should_stop)
+        spans = [(d.rel, d.line, d.end_line)
+                 for d in self._find_defs(name, path, should_stop)]
+        best = None
+        for f in files:
+            if should_stop and should_stop():
+                break
+            _defs, refs = self._extract(f)
+            lines = None
+            for rname, rel, ln in refs:
+                if rname != target:
+                    continue
+                inside = any(r == rel and a <= ln <= b for r, a, b in spans)
+                if inside and best is not None:
+                    continue
+                if lines is None:
+                    try:
+                        with open(f, errors="replace") as fh:
+                            lines = fh.read().splitlines()
+                    except OSError:
+                        break
+                if not 0 < ln <= len(lines):
+                    continue
+                m = word.search(lines[ln - 1])
+                if not m:
+                    continue
+                site = (rel, ln - 1, m.start())
+                if not inside:
+                    return site
+                best = best or site
+        return best
+
+    def definition(self, name: str, path=None, should_stop=None) -> str:
+        """Where a symbol is really DEFINED, resolved from one of its use sites.
+
+        The difference from `find_symbol`, and the only reason this exists: the
+        language server follows imports, aliases and scope, so when several
+        symbols share a name it answers with THE one this code actually means,
+        not the candidate list. Degrades to the tree-sitter name match — labelled
+        as such, never silently — when no server is available for the language."""
+        site = self._use_site(name, path, should_stop)
+        if site is not None:
+            rel, row, col = site
+            from . import lsp  # lazy: don't weigh servers until precision is asked for
+            try:
+                locs = lsp.service().definition(rel, row, col)
+            except Exception:  # noqa: BLE001 - a dead server falls back, never raises
+                locs = None
+            if locs:
+                out = []
+                for drel, dline in locs[:20]:
+                    out.append(f"{drel}:{dline}  {self._def_sig(drel, dline)}".rstrip())
+                head = (f"[{len(out)} definition{'s' if len(out) != 1 else ''}, precise "
+                        f"(language server, resolved from the use at {rel}:{row + 1})]\n")
+                return head + "\n".join(out)
+        # fallback: tree-sitter name match — same data find_symbol shows, but the
+        # degraded precision is stated (no server, or no use site to ask from).
+        hits = self._find_defs(name, path, should_stop)
+        if not hits:
+            return f"[no definition found for '{name}']"
+        rows = [f"{h.rel}:{h.line}  {h.kind}  {h.sig}" for h in hits[:100]]
+        head = (f"[{len(hits)} candidate definition{'s' if len(hits) != 1 else ''} — "
+                f"NAME-MATCH ONLY (no language server for this file type); may include "
+                f"unrelated same-named symbols, verify before editing]\n")
+        return head + "\n".join(rows)
+
+    def _def_sig(self, rel, line):
+        """`kind sig` for the definition at rel:line, or "" — decoration for a
+        precise hit, matched by span so a server pointing at the body's first line
+        still names the enclosing symbol."""
+        try:
+            defs, _ = self._extract(os.path.join(self.root, rel))
+        except Exception:  # noqa: BLE001
+            return ""
+        for d in defs:
+            if d.line == line:
+                return f"{d.kind}  {d.sig}"
+        for d in defs:
+            if d.line <= line <= d.end_line:
+                return f"in {d.kind} {d.sig}"
+        return ""
 
     def view_symbol(self, name: str, path=None, should_stop=None) -> str:
         hits = self._find_defs(name, path, should_stop)

--- a/src/chad/tools.py
+++ b/src/chad/tools.py
@@ -1699,6 +1699,8 @@ DISPATCH = {
     "view_symbol": lambda a, ss=None: repomap.service().view_symbol(
         a["name"], a.get("path"), should_stop=ss),
     "find_symbol": lambda a, ss=None: repomap.service().find_symbol(a["name"], should_stop=ss),
+    "definition": lambda a, ss=None: repomap.service().definition(
+        a["name"], a.get("path"), should_stop=ss),
     "find_refs": lambda a, ss=None: repomap.service().find_refs(
         a["name"], a.get("path"), should_stop=ss),
     "hover": lambda a, ss=None: repomap.service().hover(
@@ -2054,6 +2056,27 @@ SCHEMAS: list[dict[str, Any]] = [
     {
         "type": "function",
         "function": {
+            "name": "definition",
+            "description": "Jump from a USE of a symbol to where it is really DEFINED — "
+                           "precise (the language server follows imports and aliases, so "
+                           "when several things share a name you get THE one this code "
+                           "means, not a candidate list). Use find_symbol instead when you "
+                           "only want to list everything with that name. Name may be "
+                           "'Class/method'; pass path to resolve from a use in that file.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Symbol or 'Class/method'."},
+                    "path": {"type": "string",
+                             "description": "Optional file to resolve the use site from."},
+                },
+                "required": ["name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "find_refs",
             "description": "Find every place a symbol is USED across the project — precise "
                            "(a real language server follows imports and scope, so it won't "
@@ -2155,8 +2178,8 @@ SCHEMAS: list[dict[str, Any]] = [
 # both arms of `run_evals.py --ab` in-process: the harness flips CHAD_NO_SYMBOLS
 # between arms and the agent's render path calls active_schemas() each turn. SCHEMAS
 # itself stays the full list (name lookups / required-arg validation need every tool).
-_SYMBOLIC = {"repo_map", "overview", "view_symbol", "find_symbol", "find_refs",
-             "hover", "replace_symbol", "insert_symbol", "rename_symbol"}
+_SYMBOLIC = {"repo_map", "overview", "view_symbol", "find_symbol", "definition",
+             "find_refs", "hover", "replace_symbol", "insert_symbol", "rename_symbol"}
 
 
 def _activate_skill_schema(names):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,20 @@ def _spill_tmpdir(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _fresh_ambient(monkeypatch):
+    """Isolate ambient session state between tests, and stub the
+    env-manifest builder: with the suite's CHAD_ENABLE=all, every Agent/prompt
+    construction would otherwise spawn a dozen real `--version` subprocesses per
+    test. test_ambient.py un-stubs it explicitly to test the real builder."""
+    from chad import ambient
+    ambient.reset()
+    monkeypatch.setattr(ambient, "_build_manifest",
+                        lambda: "- present: python3 3.11 · git 2.43")
+    yield
+    ambient.reset()
+
+
+@pytest.fixture(autouse=True)
 def _fresh_file_seen():
     """Isolate the per-session freshness bookkeeping (tools._FILE_SEEN)
     between tests — a leftover seen-hash from one test must not make another test's

--- a/tests/test_ambient.py
+++ b/tests/test_ambient.py
@@ -1,0 +1,277 @@
+"""The ambient state channel: env_manifest / session_ledger / bash_read_skeleton.
+
+The design contract under test, in order of importance:
+
+1. OFF is byte-identical — with the three levers disabled, `annotate` returns its
+   input unchanged and the system prompt carries no manifest block (the 1.10.0
+   bare-default contract).
+2. Bookkeeping is lever-independent — state is true even while the levers are
+   off, so one enabled mid-session (the eval harness flips CHAD_ENABLE between
+   tasks in-process) sees real history, not history that started when it did.
+3. Facts, with dedup — the ledger states what happened with provenance, elides
+   when nothing changed, and every emission is a fired() event.
+"""
+
+import subprocess
+
+import pytest
+
+from chad import ambient, levers
+
+# Captured at module import, BEFORE the conftest autouse fixture stubs it for the
+# rest of the suite — the manifest tests below exercise the real builder.
+_REAL_BUILD_MANIFEST = ambient._build_manifest
+
+
+@pytest.fixture
+def bare(monkeypatch):
+    """Levers at the shipped default (all OFF), ambient state fresh."""
+    monkeypatch.delenv("CHAD_ENABLE", raising=False)
+    monkeypatch.delenv("CHAD_DISABLE", raising=False)
+    ambient.reset()
+
+
+@pytest.fixture
+def on(monkeypatch):
+    """Only the ambient levers ON — isolates them from the other 48."""
+    monkeypatch.setenv("CHAD_ENABLE",
+                       "env_manifest,session_ledger,bash_read_skeleton")
+    monkeypatch.delenv("CHAD_DISABLE", raising=False)
+    ambient.reset()
+
+
+def test_levers_registered():
+    for name in ("env_manifest", "session_ledger", "bash_read_skeleton"):
+        assert name in levers.LEVERS
+        assert levers.LEVERS[name].group == "ambient"
+    # env_manifest's whole effect is prompt content; the instrumentation gate
+    # enforces the annotation/code agreement, this pins the intent.
+    assert levers.LEVERS["env_manifest"].fires == levers.PASSIVE
+
+
+# ---------------------------------------------------------------------------
+# contract 1: OFF is byte-identical
+# ---------------------------------------------------------------------------
+
+def test_off_is_byte_identical(bare):
+    r1 = ambient.annotate("edit", {"path": "a.py"}, "[edited a.py]")
+    r2 = ambient.annotate("bash", {"command": "cat a.py"}, "body")
+    r3 = ambient.annotate("read", {"path": "a.py"}, "1  x = 1")
+    assert (r1, r2, r3) == ("[edited a.py]", "body", "1  x = 1")
+    assert ambient.ledger_suffix() == ""
+
+
+def test_manifest_absent_when_off(bare, monkeypatch):
+    monkeypatch.setattr(ambient, "_build_manifest", lambda: "- present: gcc 13")
+    assert ambient.env_manifest() == ""
+    from chad.prompt import build_system_prompt
+    assert "Environment manifest" not in build_system_prompt()
+
+
+# ---------------------------------------------------------------------------
+# contract 2: bookkeeping runs while off
+# ---------------------------------------------------------------------------
+
+def test_state_tracked_while_off_then_visible_when_enabled(bare, monkeypatch):
+    ambient.annotate("edit", {"path": "a.py"}, "[edited a.py]")
+    ambient.annotate("bash", {"command": "python3 -m pytest -q"}, "[exit 1]\n1 failed")
+    monkeypatch.setenv("CHAD_ENABLE", "session_ledger")
+    suffix = ambient.ledger_suffix()
+    assert "edited: a.py" in suffix
+    assert "python3 → exit 1" in suffix  # head + exit status, with provenance
+    assert "this call" in suffix  # the run was the most recent call at readout
+
+
+# ---------------------------------------------------------------------------
+# session ledger (E2)
+# ---------------------------------------------------------------------------
+
+def test_ledger_rides_landed_mutations_only(on):
+    before = levers.fire_counts().get("session_ledger", 0)
+    read = ambient.annotate("read", {"path": "a.py"}, "1  x = 1")
+    assert "[session]" not in read
+    missed = ambient.annotate("edit", {"path": "a.py"}, "[edit failed: no match]")
+    assert "[session]" not in missed  # a rejected edit changed nothing
+    landed = ambient.annotate("edit", {"path": "a.py"}, "[edited a.py]")
+    assert "[session] edited: a.py" in landed
+    assert "no verifying run yet" in landed
+    assert levers.fire_counts()["session_ledger"] == before + 1
+
+
+def test_ledger_symbols_writes_and_provenance(on):
+    ambient.annotate("replace_symbol", {"name": "parse", "path": "x.py"},
+                     "[replaced parse]")
+    ambient.annotate("bash", {"command": "python3 check.py"}, "ok")
+    out = ambient.annotate("write", {"path": "answer.txt"}, "[wrote 12 bytes]")
+    assert "edited: x.py·parse()" in out
+    assert "wrote: answer.txt" in out
+    assert "(python3 → exit 0)" in out
+
+
+def test_ledger_dedups_unchanged_state_but_not_new_state(on):
+    first = ambient.annotate("edit", {"path": "a.py"}, "[edited a.py]")
+    assert "[session]" in first
+    again = ambient.annotate("edit", {"path": "a.py"}, "[edited a.py]")
+    assert "[session]" not in again  # same file, same facts — elided
+    other = ambient.annotate("edit", {"path": "b.py"}, "[edited b.py]")
+    assert "[session]" in other and "b.py" in other
+    # force= (the done-bounce path) restates current facts through the dedup
+    assert "[session]" in ambient.ledger_suffix(force=True)
+
+
+def test_runner_wrappers_count_as_verifying_runs(on):
+    """`uv run pytest` is a pytest run — the wrapper is stripped before the
+    executing check (ambient-only; the verify gate's regex is untouched)."""
+    ambient.annotate("edit", {"path": "a.py"}, "[edited a.py]")
+    out = ambient.annotate("bash", {"command": "uv run pytest -q"},
+                           "[exit 1]\n2 failed")
+    assert out == "[exit 1]\n2 failed"  # bash results never carry the ledger
+    assert "(pytest → exit 1)" in ambient.ledger_suffix(force=True)
+
+
+def test_trivial_and_nonexecuting_bash_is_not_a_verifying_run(on):
+    ambient.annotate("edit", {"path": "a.py"}, "[edited a.py]")
+    ambient.annotate("bash", {"command": "python3 --version"}, "Python 3.11")
+    ambient.annotate("bash", {"command": "ls -la"}, "total 8")
+    assert "no verifying run yet" in ambient.ledger_suffix(force=True)
+
+
+def test_revert_clears_edit_facts(on):
+    ambient.annotate("edit", {"path": "a.py"}, "[edited a.py]")
+    ambient.annotate("bash", {"command": "git checkout ."}, "[no output]")
+    assert ambient.ledger_suffix(force=True) == ""  # nothing landed = nothing to state
+
+
+# ---------------------------------------------------------------------------
+# bash/read skeleton (E3)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def srcfile(tmp_path, monkeypatch):
+    p = tmp_path / "mod.py"
+    p.write_text("def alpha():\n    return 1\n\n\ndef beta():\n    return 2\n\n\n"
+                 "class Gamma:\n    def m(self):\n        return 3\n")
+    monkeypatch.chdir(tmp_path)  # repomap.service() re-roots on cwd change
+    return "mod.py"
+
+
+def test_skeleton_rides_bash_cat_once_per_session(on, srcfile):
+    out = ambient.annotate("bash", {"command": f"cat {srcfile}"}, "def alpha(): ...")
+    assert f"[file] {srcfile}:" in out
+    assert "alpha() 1-2" in out and "Gamma 9-11" in out
+    again = ambient.annotate("bash", {"command": f"cat {srcfile}"}, "def alpha(): ...")
+    assert "[file]" not in again  # once per file per session
+
+
+def test_skeleton_rides_read_but_not_error_results(on, srcfile):
+    miss = ambient.annotate("read", {"path": "nope.py"}, "[no such file: nope.py]")
+    assert "[file]" not in miss
+    out = ambient.annotate("read", {"path": srcfile}, "1  def alpha():")
+    assert f"[file] {srcfile}:" in out
+
+
+def test_skeleton_skips_structureless_and_tiny_files(on, tmp_path, monkeypatch):
+    p = tmp_path / "flat.py"
+    p.write_text("x = 1\n")
+    monkeypatch.chdir(tmp_path)
+    out = ambient.annotate("bash", {"command": "cat flat.py"}, "x = 1")
+    assert "[file]" not in out
+
+
+def test_zero_hit_grep_gets_definition_pointer(on, srcfile):
+    out = ambient.annotate("bash", {"command": "grep -rn beta src/"}, "[exit 1]")
+    assert "`beta` is defined at mod.py:5" in out
+    # a non-identifier or found grep gets nothing
+    ok = ambient.annotate("bash", {"command": "grep -rn beta ."}, "mod.py:5:def beta")
+    assert "[file]" not in ok
+
+
+# ---------------------------------------------------------------------------
+# env manifest (E1)
+# ---------------------------------------------------------------------------
+
+def test_manifest_content_and_prompt_block(on, monkeypatch):
+    fake = {"python3": "/usr/bin/python3", "gcc": "/usr/bin/gcc",
+            "apt-get": "/usr/bin/apt-get", "pip": "/usr/bin/pip"}
+
+    def fake_run(argv, **kw):
+        class P:
+            stdout = {"python3": "Python 3.11.9", "gcc": "gcc (Ubuntu) 13.3.0",
+                      "pip": "pip 24.0 from ..."}.get(argv[0], "")
+            stderr = ""
+        return P()
+
+    # Scoped: `ambient.subprocess` IS the global module, and build_system_prompt
+    # below legitimately uses subprocess.run for the workspace snapshot.
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(ambient.shutil, "which", lambda t: fake.get(t))
+        mp.setattr(ambient.subprocess, "run", fake_run)
+        body = _REAL_BUILD_MANIFEST()
+    assert "python3 3.11.9" in body and "gcc 13.3.0" in body
+    assert "NOT installed: " in body and "cargo" in body and "docker" in body
+    assert "package managers: apt-get, pip" in body
+
+    monkeypatch.setattr(ambient, "_build_manifest", lambda: body)
+    ambient.reset()
+    from chad.prompt import build_system_prompt
+    prompt = build_system_prompt()
+    assert "# Environment manifest" in prompt
+    assert "later installs are NOT reflected" in prompt
+    assert "python3 3.11.9" in prompt
+
+
+def test_manifest_built_once_per_session(on, monkeypatch):
+    calls = []
+    monkeypatch.setattr(ambient, "_build_manifest",
+                        lambda: calls.append(1) or "- present: git 2.43")
+    assert ambient.env_manifest() == ambient.env_manifest()
+    assert len(calls) == 1
+
+
+def test_manifest_alias_family_absence(on, monkeypatch):
+    """pip3-without-pip must not report 'NOT installed: pip' — absence is claimed
+    only when the whole alias family is missing."""
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(ambient.shutil, "which",
+                   lambda t: "/usr/bin/x" if t in ("pip3", "python") else None)
+        mp.setattr(ambient, "_probe_version", lambda t: "")
+        body = _REAL_BUILD_MANIFEST()
+    assert "pip3" in body and "python" in body
+    assert "NOT installed: gcc" in body
+    for family in ("pip,", "pip\n", "python3"):
+        assert family not in body.split("NOT installed:")[1].split("\n")[0] + "\n"
+
+
+def test_manifest_probe_survives_broken_tool(on, monkeypatch):
+    def boom(argv, **kw):
+        raise subprocess.TimeoutExpired(argv, 1.5)
+    monkeypatch.setattr(ambient.subprocess, "run", boom)
+    monkeypatch.setattr(ambient.shutil, "which",
+                        lambda t: "/usr/bin/x" if t in ("gcc", "apt-get") else None)
+    body = _REAL_BUILD_MANIFEST()
+    assert "gcc" in body  # present, just unversioned
+
+
+# ---------------------------------------------------------------------------
+# agent integration
+# ---------------------------------------------------------------------------
+
+def test_annotate_is_wired_into_the_agent_loop():
+    """The hook exists on the main-agent dispatch path and is sub-agent-gated —
+    pinned textually (an e2e exercise lives in the feel pack; this keeps the
+    wiring from silently vanishing in a refactor)."""
+    import inspect
+
+    from chad import agent
+    src = inspect.getsource(agent.Agent._run_turn)
+    assert "ambient.annotate(name, args, result" in src
+    assert "if not self._subagent:" in src.split("ambient.annotate")[0].rsplit(
+        "guardrails.elide_duplicate_result", 1)[-1]
+
+
+def test_ledger_rides_done_bounces():
+    import inspect
+
+    from chad import agent
+    src = inspect.getsource(agent.Agent._run_turn)
+    assert src.count("ambient.ledger_suffix(step=step, force=True)") >= 2

--- a/tests/test_lever_bite.py
+++ b/tests/test_lever_bite.py
@@ -832,6 +832,53 @@ def test_post_edit_diagnostics_bite(tmp_path, monkeypatch):
     assert "typecheck" not in edit(3)
 
 
+# === group "ambient": facts in the result channel ==========================
+
+def test_env_manifest_bite(monkeypatch):
+    """The manifest block exists with the lever on and is absent — not empty-ish,
+    absent — with it off. (The builder is stubbed suite-wide in conftest.)"""
+    from chad import ambient
+    n = bite("env_manifest")
+    on(monkeypatch)
+    ambient.reset()
+    assert "present:" in ambient.env_manifest()
+    off(monkeypatch, n)
+    ambient.reset()
+    assert ambient.env_manifest() == ""
+
+
+def test_session_ledger_bite(monkeypatch):
+    """The same landed edit carries the [session] fact line with the lever on and
+    is byte-identical to the bare result with it off."""
+    from chad import ambient
+    n = bite("session_ledger")
+    on(monkeypatch)
+    ambient.reset()
+    assert "[session] edited: a.py" in ambient.annotate(
+        "edit", {"path": "a.py"}, "[edited a.py]")
+    off(monkeypatch, n)
+    ambient.reset()
+    assert ambient.annotate("edit", {"path": "a.py"}, "[edited a.py]") == "[edited a.py]"
+
+
+def test_bash_read_skeleton_bite(tmp_path, monkeypatch):
+    """The same `cat` result carries the [file] structure line with the lever on
+    and is byte-identical with it off."""
+    from chad import ambient
+    n = bite("bash_read_skeleton")
+    (tmp_path / "m.py").write_text(
+        "def a():\n    pass\n\n\ndef b():\n    pass\n\n\ndef c():\n    pass\n")
+    monkeypatch.chdir(tmp_path)
+    on(monkeypatch)
+    ambient.reset()
+    assert "[file] m.py:" in ambient.annotate(
+        "bash", {"command": "cat m.py"}, "def a(): ...")
+    off(monkeypatch, n)
+    ambient.reset()
+    assert ambient.annotate(
+        "bash", {"command": "cat m.py"}, "def a(): ...") == "def a(): ..."
+
+
 # === the coverage contract =================================================
 
 def test_every_registered_lever_has_a_bite_test():

--- a/tests/test_repomap.py
+++ b/tests/test_repomap.py
@@ -350,6 +350,91 @@ def test_disambig_budget_and_cache(tmp_path=None):
         lsp_mod._SERVICE = real_svc
 
 
+def test_definition_precise_and_fallback(tmp_path=None):
+    """`definition` resolves a use site to THE definition via the
+    language server, and says which precision it is.
+
+    The case that makes it worth a tool of its own: two files define `target`, so
+    `find_symbol` can only hand back both. The server knows which one `app.py`
+    actually imported. When there is no server, the answer degrades to the
+    name-match list — labelled, never silently."""
+    import os as _os
+    import pathlib
+    import tempfile
+
+    import chad.lsp as lsp_mod
+
+    if tmp_path is None:
+        tmp_path = pathlib.Path(tempfile.mkdtemp(prefix="repomap_definition_"))
+    (tmp_path / "right.py").write_text("def target():\n    return 1\n")
+    (tmp_path / "wrong.py").write_text("def target():\n    return 2\n")
+    (tmp_path / "app.py").write_text(
+        "from right import target\n\n\ndef run():\n    return target()\n")
+
+    rm = RepoMap(str(tmp_path))
+    rm._disk_checked = True
+
+    # -- no language server: name-match fallback, honestly labelled -------
+    class _NoServer:
+        def __init__(self):
+            self.root = _os.path.abspath(_os.getcwd())
+
+        def definition(self, rel, row, col):
+            return None
+
+    real_svc = lsp_mod._SERVICE
+    lsp_mod._SERVICE = _NoServer()
+    try:
+        out = rm.definition("target")
+        check("no server -> both candidates listed",
+              "right.py" in out and "wrong.py" in out, out)
+        check("no server -> degraded precision is stated",
+              "NAME-MATCH ONLY" in out, out)
+        check("no server -> not claimed precise", "precise" not in out, out)
+    finally:
+        lsp_mod._SERVICE = real_svc
+
+    # -- with a server: one answer, and it is the imported one ------------
+    class _Server:
+        def __init__(self):
+            self.root = _os.path.abspath(_os.getcwd())
+            self.asked = []
+
+        def definition(self, rel, row, col):
+            self.asked.append((rel, row, col))
+            return [("right.py", 1)]
+
+    svc = _Server()
+    lsp_mod._SERVICE = svc
+    try:
+        out = rm.definition("target")
+        check("server -> the one real definition", "right.py:1" in out, out)
+        check("server -> the wrong same-named symbol is not offered",
+              "wrong.py" not in out, out)
+        check("server -> precision is claimed explicitly", "precise" in out, out)
+        check("server -> the definition is decorated with its signature",
+              "def target" in out, out)
+        check("server was asked at a USE site, not at a definition",
+              svc.asked and svc.asked[0][0] == "app.py", svc.asked)
+    finally:
+        lsp_mod._SERVICE = real_svc
+
+    check("an unknown name is a clean miss, not a crash",
+          "no definition found" in rm.definition("nope_not_here"))
+
+
+def test_definition_is_wired_into_the_toolset():
+    """Implemented-and-unreachable was the bug: the service method
+    existed with no tool schema. Pin every wiring point so it cannot regress."""
+    from chad import tools
+    check("dispatchable", "definition" in tools.DISPATCH)
+    names = {s["function"]["name"] for s in tools.SCHEMAS}
+    check("has a tool schema", "definition" in names)
+    check("joins the CHAD_NO_SYMBOLS A/B arm", "definition" in tools._SYMBOLIC)
+    exposed = {s["function"]["name"] for s in tools.active_schemas()}
+    check("exposed to the model by default", "definition" in exposed)
+
+
 if __name__ == "__main__":
     test_repomap()
     test_repo_map_edge_aggregation()
@@ -358,6 +443,8 @@ if __name__ == "__main__":
     test_parallel_extract()
     test_aggregate_memoization()
     test_disambig_budget_and_cache()
+    test_definition_precise_and_fallback()
+    test_definition_is_wired_into_the_toolset()
     print(f"\n{passed} passed, {failed} failed")
     raise SystemExit(1 if failed else 0)
 

--- a/tests/test_repomap_polyglot.py
+++ b/tests/test_repomap_polyglot.py
@@ -101,6 +101,37 @@ def test_cross_file_refs(lang):
 
 
 @pytest.mark.parametrize("lang", sorted(LANGS))
+def test_definition_resolves_to_the_defining_file(lang):
+    """`definition(helper)` must land on lib, where helper is defined — resolved
+    from its use in app. No language server is installed in the fast gate, so this
+    exercises the tree-sitter fallback; either way the answer must name lib and
+    must state which precision it is (confidence honesty)."""
+    helper, _process, _run, _container, lib, _app = LANGS[lang]
+    rm = _map_for(lang)
+    out = rm.definition(helper)
+    assert lib in out, out
+    assert ("precise (language server" in out) or ("NAME-MATCH ONLY" in out), out
+
+
+@pytest.mark.parametrize("lang", sorted(LANGS))
+def test_definition_use_site_is_a_use_not_the_definition(lang):
+    """The site `definition` asks the language server about must be a USE of the
+    symbol. Asking at the definition is the bug this guards: go-to-definition
+    there answers with itself (or nothing), which would silently strand every
+    lookup on the name-match fallback."""
+    helper, _process, _run, _container, lib, app = LANGS[lang]
+    rm = _map_for(lang)
+    site = rm._use_site(helper)
+    assert site is not None, "no use site found for %s" % helper
+    rel, row, col = site
+    assert rel == app, site  # helper is *called* in app, *defined* in lib
+    with open(os.path.join(FIXTURES, lang, rel), errors="replace") as fh:
+        line = fh.read().splitlines()[row]
+    assert line[col:col + len(helper)] == helper, (line, col)
+    assert lib != rel
+
+
+@pytest.mark.parametrize("lang", sorted(LANGS))
 def test_same_name_two_files_disambiguates(lang):
     """The colliding name is defined in two files; a bare view_symbol must return
     the disambiguation listing naming both, not silently pick one."""

--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,7 @@ wheels = [
 
 [[package]]
 name = "chad-code"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },


### PR DESCRIPTION
- **New tool: `definition(name)`** — jump from a *use* of a symbol to the one
  place it is really defined, following imports and aliases through the language
  server (pyright/TS/gopls/rust-analyzer/clangd/…), with the honestly-labeled
  tree-sitter name-match as fallback. The capability had existed since 1.0.7;
  no tool schema exposed it — the model could never call it. Asked at a use
  site, not the definition (asking at the definition answers with itself), so
  two files defining `target` resolve to the one your file actually imports.
  Verified across 13 fixture languages.
- **Three new "ambient state" levers (default OFF, like everything since
  1.10.0): the harness states facts in the results the model already reads,
  instead of steering it toward tools it demonstrably won't call.** Trace
  measurement over ~140k tool calls showed the model routes ~83% of its
  searching through `bash` and calls the symbolic tools ~never, under a prompt
  that already says not to — so these meet it on the route it chose:
  - `env_manifest` — a session-start toolchain inventory in the system prompt
    (compilers/interpreters with versions, notable absences, package managers;
    ~75 tokens, built once in <1s, prefix-resident). Answers the
    `which`/`--version`/`pip list` probe chains up front — measured at 3.3
    probes per failing trial, 37% of them failing.
  - `session_ledger` — one cumulative fact line on landed edits and done
    bounces: `[session] edited: x.py·parse() · wrote: answer.txt · last
    verifying run: 2 calls ago (pytest → exit 1)`. Facts with provenance,
    never instructions; revert-aware; elided when unchanged. Aimed at the
    largest measured failure class — confident `done`s built on a stale
    mental model of what changed and what was actually re-run.
  - `bash_read_skeleton` — the first time a source file's content comes back
    through `cat`/`sed`/`read`, the result carries a one-line symbol map
    (`[file] mod.py: alpha() 1-2 · Gamma 9-11`); a zero-hit `grep` for a
    symbol the tags cache knows gets its real definition site. Symbol
    intelligence with no new tool name to learn.

  Enable with `CHAD_ENABLE=env_manifest,session_ledger,bash_read_skeleton` (or
  `all`); each is instrumented (`fired()` telemetry) and A/B-able on its own.