### PR TITLE
Release/1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,42 @@
 
 Notable, user-visible changes.
 
-## [Unreleased]
+## [1.12.0] — 2026-08-07
 
+- **Sandbox hardening — the confinement must prove itself before it may be
+  claimed:**
+  - `yolo_seatbelt`'s startup probe now checks **enforcement in both
+    directions** against a throwaway directory pair: the allowed write must
+    land AND the denied write must not. The old probe only proved
+    `sandbox-exec` could run a permissive profile — a profile failing open
+    (OS drift, a malformed rule) would have reported confinement it did not
+    have, the worst failure a safety lever can have. A denied write that
+    lands now refuses the sandbox with a loud log; either failure runs
+    unconfined and says so. (The probe promptly caught a real member of this
+    class: an allow rule written against the `$TMPDIR` symlink spelling that
+    Seatbelt, matching the kernel's real path, silently denied.)
+  - The undo history (`~/.chad/checkpoints`, the `edit_checkpoint` shadow
+    repo) is now **write-denied inside the sandbox**, closing the gap where
+    it was reachable through the allowed `~/.chad` subpath — a sandboxed
+    command could previously delete the very snapshots `/undo` restores
+    from. Costs real commands nothing: only chad's own never-sandboxed
+    process writes there.
+- **Two new "safety" levers (default OFF):**
+  - `seatbelt_protect_git` — opt-in tier on top of `yolo_seatbelt`: the
+    workspace's git metadata (`.git`, and a worktree's external gitdir +
+    common dir) becomes write-denied inside the otherwise-writable
+    workspace, so an unreviewed command cannot `rm -rf .git` the project's
+    history. The cost is real — every `.git`-writing git command (commit,
+    add, checkout) EPERMs, sized statically at ≤2.65% of 91,910 real session
+    commands, concentrated in 14% of sessions — which is why it is its own
+    lever rather than part of the base profile.
+  - `bash_env_guard` — spawned bash children get a filtered copy of the
+    environment: variable names shaped like credentials (`…_TOKEN`,
+    `…_SECRET`, `…_PASSWORD`, `…_API_KEY`, `…_ACCESS_KEY`, `…_PRIVATE_KEY`)
+    are dropped, name-pattern only, values never read. A filesystem sandbox
+    that still hands every command the operator's cloud keys is a half-closed
+    boundary; commands that legitimately need a credential need the lever
+    off (it defaults off, preserving inherit-all).
 - **Two new "safety" levers (default OFF, like everything since 1.10.0) —
   blast-radius containment for unattended mutation:**
   - `yolo_seatbelt` — in yolo mode on macOS, each bash command's shell child

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 Notable, user-visible changes.
 
+## [Unreleased]
+
+- **Two new "safety" levers (default OFF, like everything since 1.10.0) —
+  blast-radius containment for unattended mutation:**
+  - `yolo_seatbelt` — in yolo mode on macOS, each bash command's shell child
+    runs under a Seatbelt profile (`sandbox-exec`) that denies file writes
+    outside the workspace, temp dirs, tool caches, and `~/.chad`. Reads,
+    network, and exec stay open, and the model process itself is never
+    sandboxed — only the spawned shell. A detected denial gets a one-line
+    explanation appended to the tool result so the model routes around the
+    boundary instead of retrying into it. Environments where Seatbelt can't
+    apply (CI, nested sandboxes) are probed once and run unconfined.
+    Sized against 91,910 real session commands: 94.3% write only inside the
+    allowlist; the denials are the system-admin writes the sandbox exists for.
+  - `edit_checkpoint` — before a file-mutating tool lands, the workspace is
+    committed to a shadow git repo under `~/.chad/checkpoints` (the project's
+    own `.git` is never touched, written, or required to exist). New TUI
+    commands: `/undo` reverts files to the last checkpoint, `/restore` lists
+    checkpoints and reverts to a chosen one. Restores put snapshotted content
+    back but never delete files created since — deleting is exactly the blast
+    radius this lever contains. Snapshot cost measured at ~56ms per edit on a
+    167-file repo (~84ms at 3,000 files).
+
 ## [1.11.0] — 2026-08-06
 
 - **New tool: `definition(name)`** — jump from a *use* of a symbol to the one

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # import name, and command name are independent. `uvx chad-code` runs the alias
 # script added under [project.scripts].
 name = "chad-code"
-version = "1.11.0"
+version = "1.12.0"
 description = "Local MLX-backed, Claude-Code-style coding agent (Apple Silicon, Ornith 35B/9B)"
 readme = "README.md"
 license = "MIT"

--- a/src/chad/__init__.py
+++ b/src/chad/__init__.py
@@ -4,7 +4,7 @@ A flat collection of cooperating modules behind one console script (``chad``):
 the inference engine, the tool layer, the agent loop, and the terminal UI.
 """
 
-__version__ = "1.11.0"
+__version__ = "1.12.0"
 
 # chad sets no MLX_* runtime vars. MLX_METAL_FAST_SYNCH, MLX_MAX_OPS_PER_BUFFER
 # and MLX_MAX_MB_PER_BUFFER were each measured end-to-end on the 35B and every

--- a/src/chad/agent.py
+++ b/src/chad/agent.py
@@ -14,7 +14,18 @@ import re
 import sys
 import time
 
-from . import ambient, atif, compaction, config, guardrails, levers, session, syntaxgate
+from . import (
+    ambient,
+    atif,
+    checkpoint,
+    compaction,
+    config,
+    guardrails,
+    levers,
+    seatbelt,
+    session,
+    syntaxgate,
+)
 from .base_engine import BackendError, BaseEngine
 from .diag import args_preview, log, redact, result_preview
 from .prompt import build_subagent_prompt, build_system_prompt, classify_intent
@@ -1971,12 +1982,27 @@ class Agent:
                 else:
                     _t0 = time.perf_counter()
                     self.tool_dispatches += 1
+                    # A snapshot happens AFTER approval, immediately before the tool
+                    # runs — a denied edit must not leave a checkpoint claiming it ran.
+                    if (name in AUTO_EDIT_TOOLS
+                            and levers.enabled("edit_checkpoint")):
+                        _ref = checkpoint.snapshot(
+                            os.getcwd(), f"before {name} {args.get('path', '')}".strip())
+                        if _ref:
+                            levers.fired("edit_checkpoint", step=step, ref=_ref)
+                    # Seatbelt context is scoped to exactly this dispatch: `active`
+                    # reflects the mode of the agent actually executing, so a
+                    # sub-agent's yolo loop is confined inside a normal-mode parent
+                    # turn, and the context can't leak to the `!cmd` passthrough.
+                    seatbelt.set_context(self.mode == "yolo", os.getcwd())
                     try:
                         result = fn(args, self._should_stop)
                         if plan_write and result.startswith("[wrote"):
                             self.last_plan_path = os.path.abspath(args["path"])
                     except Exception as e:  # noqa: BLE001 - surface tool errors to model
                         result = f"[tool error: {type(e).__name__}: {e}]"
+                    finally:
+                        seatbelt.set_context(False, None)
                     _tool_s = time.perf_counter() - _t0
                     # Backstop: bound the prefill from any tool, AND from the step as a
                     # whole — several calls in one step stack into one prefill, so later

--- a/src/chad/checkpoint.py
+++ b/src/chad/checkpoint.py
@@ -1,0 +1,150 @@
+"""Shadow-git checkpoints for file edits (lever: edit_checkpoint).
+
+Auto-approved edits are justified as "a diff you can read and revert" — this
+module supplies the revert. Before each file-mutating tool lands, the workspace
+is committed to a *shadow* git repository under ~/.chad/checkpoints/<hash>. The
+user's own .git is never opened, never written, never required to exist: the
+shadow repo has its own GIT_DIR and treats the workspace purely as a work tree.
+/undo and /restore in the TUI check files back out of it.
+
+Failure policy: never raise. An edit must not die because the checkpoint
+machinery hiccuped — snapshot() returns None on any failure and the tool call
+proceeds unprotected (logged, and visible in `chad levers` firing counts as the
+absence of a fire).
+
+Restore policy (deliberately conservative): `git restore --source=<ref>` puts
+every snapshotted file back to its snapshotted content. Files *created after*
+the snapshot are left in place — deleting files is exactly the blast radius this
+lever exists to contain, so the restore path never does it.
+"""
+
+import hashlib
+import logging
+import os
+import subprocess
+from typing import Optional
+
+log = logging.getLogger("chad")
+
+_GIT_TIMEOUT_S = 120  # first snapshot of a big tree is seconds; never hang a turn
+
+# Junk that snapshots must not swallow when the workspace has no .gitignore of its
+# own (a non-git project): written to the shadow repo's info/exclude, which
+# composes with any workspace .gitignore rather than replacing it.
+_DEFAULT_EXCLUDES = (".venv/\nvenv/\nnode_modules/\n__pycache__/\n*.pyc\n"
+                     ".mypy_cache/\n.ruff_cache/\n.pytest_cache/\n.DS_Store\n")
+
+
+def _history_root() -> str:
+    # CHAD_CHECKPOINT_DIR: test/e2e override so suites never write real home state.
+    # NOT ~/.chad/history — that name is taken by the TUI's prompt-history FILE.
+    env = os.environ.get("CHAD_CHECKPOINT_DIR")
+    if env:
+        return env
+    return os.path.join(os.path.expanduser("~"), ".chad", "checkpoints")
+
+
+def shadow_dir(workspace: str) -> str:
+    ws = os.path.realpath(workspace)
+    tag = hashlib.sha1(ws.encode()).hexdigest()[:16]
+    return os.path.join(_history_root(), tag, "shadow.git")
+
+
+def _git(workspace: str, *args: str) -> subprocess.CompletedProcess:
+    """Run git against the shadow repo with the workspace as work tree. Identity
+    and signing come from -c flags so the user's global config is never consulted
+    for authorship and never mutated."""
+    cmd = ["git", "--git-dir", shadow_dir(workspace), "--work-tree",
+           os.path.realpath(workspace),
+           "-c", "user.email=chad@localhost", "-c", "user.name=chad",
+           "-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null",
+           *args]
+    return subprocess.run(cmd, capture_output=True, text=True,
+                          timeout=_GIT_TIMEOUT_S, check=False)
+
+
+def _ensure_shadow(workspace: str) -> bool:
+    sd = shadow_dir(workspace)
+    if os.path.isdir(sd):
+        return True
+    try:
+        os.makedirs(os.path.dirname(sd), exist_ok=True)
+        r = subprocess.run(["git", "init", "-q", "--bare", sd],
+                           capture_output=True, text=True,
+                           timeout=_GIT_TIMEOUT_S, check=False)
+        if r.returncode != 0:
+            log.warning("CHECKPOINT shadow init failed: %s", r.stderr.strip())
+            return False
+        info = os.path.join(sd, "info")
+        os.makedirs(info, exist_ok=True)
+        with open(os.path.join(info, "exclude"), "w", encoding="utf-8") as fh:
+            fh.write(_DEFAULT_EXCLUDES)
+        return True
+    except (OSError, subprocess.SubprocessError) as e:
+        log.warning("CHECKPOINT shadow init failed: %s", e)
+        return False
+
+
+def snapshot(workspace: str, label: str) -> Optional[str]:
+    """Commit the workspace state to the shadow repo; return the short hash, or
+    None if no checkpoint exists after the attempt. An unchanged tree is not a
+    failure — the previous snapshot already covers it, so its hash is returned."""
+    try:
+        if not _ensure_shadow(workspace):
+            return None
+        add = _git(workspace, "add", "-A")
+        if add.returncode != 0:
+            log.warning("CHECKPOINT add failed: %s", add.stderr.strip())
+            return None
+        commit = _git(workspace, "commit", "-q", "-m", label)
+        head = _git(workspace, "rev-parse", "--short", "HEAD")
+        if head.returncode != 0:
+            # Nothing staged AND no prior snapshot — an empty workspace's first
+            # checkpoint. Record the empty state anyway so the timeline exists.
+            commit = _git(workspace, "commit", "-q", "--allow-empty", "-m", label)
+            head = _git(workspace, "rev-parse", "--short", "HEAD")
+            if head.returncode != 0:
+                log.warning("CHECKPOINT commit failed: %s", commit.stderr.strip())
+                return None
+        return head.stdout.strip()
+    except (OSError, subprocess.SubprocessError) as e:
+        log.warning("CHECKPOINT snapshot failed: %s", e)
+        return None
+
+
+def snapshots(workspace: str, limit: int = 10) -> list:
+    """Newest-first [(short_hash, iso_time, label)] — empty on any failure."""
+    try:
+        r = _git(workspace, "log", f"-{limit}", "--format=%h%x09%cI%x09%s")
+        if r.returncode != 0:
+            return []
+        rows = []
+        for line in r.stdout.splitlines():
+            parts = line.split("\t", 2)
+            if len(parts) == 3:
+                rows.append((parts[0], parts[1], parts[2]))
+        return rows
+    except (OSError, subprocess.SubprocessError):
+        return []
+
+
+def restore(workspace: str, ref: str = "HEAD") -> str:
+    """Check snapshotted files back out at `ref`. Returns a human-readable
+    one-liner (also used verbatim by the TUI)."""
+    try:
+        ok = _git(workspace, "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}")
+        if ok.returncode != 0:
+            have = snapshots(workspace, limit=1)
+            return (f"no checkpoint named {ref!r}" if have else
+                    "no checkpoints exist for this workspace yet — snapshots are "
+                    "taken before file edits when the edit_checkpoint lever is on")
+        changed = _git(workspace, "diff", "--name-only", ref)
+        n = len([ln for ln in changed.stdout.splitlines() if ln.strip()])
+        r = _git(workspace, "restore", "--worktree", f"--source={ref}", "--", ".")
+        if r.returncode != 0:
+            return f"restore failed: {r.stderr.strip() or 'unknown git error'}"
+        label = _git(workspace, "log", "-1", "--format=%s", ref).stdout.strip()
+        return (f"restored {n} file(s) to checkpoint {ref} ({label}). Files created "
+                f"since that snapshot were left in place.")
+    except (OSError, subprocess.SubprocessError) as e:
+        return f"restore failed: {e}"

--- a/src/chad/levers.py
+++ b/src/chad/levers.py
@@ -514,6 +514,22 @@ LEVERS: dict[str, Lever] = {
         "only a server already warmed by find_refs/hover/disambiguation is "
         "consulted; absent one, silence.",
         "ctxengine"),
+
+    # --- group "safety": blast-radius containment for unattended mutation. ---------
+    "yolo_seatbelt": Lever(
+        "In yolo mode on macOS, each bash command's shell child runs under a "
+        "Seatbelt profile (sandbox-exec) that denies file writes outside the "
+        "workspace, temp dirs, tool caches, and ~/.chad — reads, network, and exec "
+        "stay open. The model process is never sandboxed, only the spawned shell. "
+        "Fires when a denial is detected in command output: each fire is a write "
+        "the command-pattern denylist did not catch.",
+        "safety"),
+    "edit_checkpoint": Lever(
+        "Before a file-mutating tool lands, commit a workspace snapshot to a "
+        "shadow git repo under ~/.chad/checkpoints (the project's own .git is "
+        "never touched or required); /undo and /restore in the TUI revert from "
+        "it. Fires once per snapshot taken and once per restore performed.",
+        "safety"),
 }
 
 

--- a/src/chad/levers.py
+++ b/src/chad/levers.py
@@ -520,7 +520,11 @@ LEVERS: dict[str, Lever] = {
         "In yolo mode on macOS, each bash command's shell child runs under a "
         "Seatbelt profile (sandbox-exec) that denies file writes outside the "
         "workspace, temp dirs, tool caches, and ~/.chad — reads, network, and exec "
-        "stay open. The model process is never sandboxed, only the spawned shell. "
+        "stay open, and ~/.chad/checkpoints (the undo history) is carved back out "
+        "so a sandboxed command cannot delete it. The model process is never "
+        "sandboxed, only the spawned shell. The startup probe proves the profile "
+        "ENFORCES (an allowed write must land, a denied write must not) before any "
+        "confinement is claimed; either failure runs unconfined with a loud log. "
         "Fires when a denial is detected in command output: each fire is a write "
         "the command-pattern denylist did not catch.",
         "safety"),
@@ -529,6 +533,30 @@ LEVERS: dict[str, Lever] = {
         "shadow git repo under ~/.chad/checkpoints (the project's own .git is "
         "never touched or required); /undo and /restore in the TUI revert from "
         "it. Fires once per snapshot taken and once per restore performed.",
+        "safety"),
+    "seatbelt_protect_git": Lever(
+        "Opt-in tier on top of yolo_seatbelt: the workspace's git metadata "
+        "(.git, and a worktree's external gitdir + common dir) is write-DENIED "
+        "inside the otherwise-writable workspace, so an unreviewed command "
+        "cannot destroy project history (`rm -rf .git`) — and with "
+        "edit_checkpoint on, the undo snapshots stay tamper-proof from inside "
+        "the sandbox too. The cost is real: every .git-writing git command "
+        "(commit, add, checkout) EPERMs — sized at <=2.65% of 91,910 real "
+        "session commands, concentrated in 14% of sessions — which is why this "
+        "is its own lever, not part of the base profile. Inert unless "
+        "yolo_seatbelt is also enabled; a denial it causes surfaces through "
+        "yolo_seatbelt's own firing (the profile cannot say which rule bit).",
+        "safety", fires=PASSIVE),
+    "bash_env_guard": Lever(
+        "Spawned bash children get a FILTERED copy of the environment: variable "
+        "names shaped like credentials (…_TOKEN, …_SECRET, …_PASSWORD, "
+        "…_API_KEY, …_ACCESS_KEY(_ID), …_PRIVATE_KEY, …_CREDENTIALS) are "
+        "dropped, closing the gap where a filesystem sandbox still hands every "
+        "command the operator's cloud keys. Name-pattern only — values are "
+        "never read or logged. OFF (the default) inherits the parent env "
+        "untouched, today's behavior; commands that legitimately need a "
+        "credential need the lever off. Fires per spawn that actually dropped "
+        "something, with the count.",
         "safety"),
 }
 

--- a/src/chad/seatbelt.py
+++ b/src/chad/seatbelt.py
@@ -1,0 +1,190 @@
+"""macOS Seatbelt confinement for yolo-mode bash commands (lever: yolo_seatbelt).
+
+The destructive-command denylist in guardrails.py is pattern-matching, not a
+boundary — it says so itself. This module is the boundary: in yolo mode (the one
+mode where a shell command runs with no human in the loop), the spawned shell is
+wrapped in `sandbox-exec` with a profile that denies file writes everywhere except
+the workspace, temp dirs, caches, and chad's own state dir. Reads and network stay
+open; the failure mode this closes is "an unreviewed command wrote outside the
+project".
+
+Only the *spawned shell child* is ever sandboxed. The chad process itself must
+never enter the sandbox: the model runs in-process on Metal, and GPU access from
+inside a Seatbelt profile is not something to gamble a session on. tool_bash asks
+`wrap_argv()` for an argv at spawn time; everything else here is profile plumbing.
+
+The active/workspace context is set by the agent immediately before each tool
+dispatch and cleared after, so nested agents (a sub-agent's yolo loop inside a
+normal-mode parent turn) and the `!cmd` passthrough each get exactly the
+confinement of the agent/mode that is actually executing.
+"""
+
+import logging
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from typing import Optional
+
+from . import levers
+
+log = logging.getLogger("chad")
+
+SANDBOX_EXEC = "/usr/bin/sandbox-exec"
+
+# One-shot capability probe. Seatbelt profiles don't nest: when chad itself runs
+# inside a sandbox (CI, a harness container, another agent's shell tool),
+# sandbox-exec fails to apply and would turn EVERY yolo bash call into an error.
+# Probe once per process; on failure run unconfined (logged) rather than broken.
+_probe_result: Optional[bool] = None
+
+# The marker a denied write leaves in command output (EPERM strerror). Used by
+# tool_bash to detect that the profile bit and to append an explanation the model
+# can act on instead of a bare permission error.
+DENIAL_MARKER = "Operation not permitted"
+DENIAL_NOTE = ("\n[seatbelt: a write outside the workspace was denied — yolo mode "
+               "confines file writes to the project directory, temp dirs, and "
+               "caches. Work inside the project, or ask the user to run this "
+               "command themselves.]")
+
+_ctx: dict = {"active": False, "workspace": None}
+
+# profile path per workspace realpath — the profile embeds absolute paths, so it is
+# only reusable for the same workspace.
+_profiles: dict = {}
+
+
+def set_context(active: bool, workspace: Optional[str]) -> None:
+    """Called by the agent around each tool dispatch. `active` is 'the executing
+    agent is in yolo mode'; whether wrapping actually happens still depends on the
+    lever and platform (see wrap_argv)."""
+    _ctx["active"] = active
+    _ctx["workspace"] = workspace
+
+
+def available() -> bool:
+    return sys.platform == "darwin" and os.path.exists(SANDBOX_EXEC)
+
+
+def probe() -> bool:
+    """Can a sandbox actually be applied from this process? Cached per process."""
+    global _probe_result
+    if _probe_result is None:
+        if not available():
+            _probe_result = False
+        else:
+            try:
+                r = subprocess.run(
+                    [SANDBOX_EXEC, "-p", "(version 1)(allow default)",
+                     "/usr/bin/true"],
+                    capture_output=True, timeout=10, check=False)
+                _probe_result = r.returncode == 0
+            except (OSError, subprocess.SubprocessError):
+                _probe_result = False
+            if not _probe_result:
+                log.warning("SEATBELT unavailable here (nested sandbox or missing "
+                            "support) — yolo bash runs unconfined")
+    return _probe_result
+
+
+def _scheme_str(path: str) -> str:
+    """Escape a path for embedding in a Scheme string literal. Paths are embedded
+    directly (no -D params): quotes and backslashes in a path must not be able to
+    terminate the string and smuggle profile syntax."""
+    return path.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _worktree_gitdirs(workspace: str) -> list:
+    """If the workspace is a `git worktree`, its `.git` is a FILE pointing at an
+    external gitdir — and every git command writes there (index, locks) and to the
+    shared common dir (objects, refs). Without these two carve-outs the sandbox
+    kills all git activity in a worktree checkout."""
+    dirs = []
+    dotgit = os.path.join(workspace, ".git")
+    if not os.path.isfile(dotgit):
+        return dirs
+    try:
+        with open(dotgit, encoding="utf-8", errors="replace") as fh:
+            m = re.match(r"gitdir:\s*(.+)", fh.read().strip())
+        if not m:
+            return dirs
+        gitdir = os.path.normpath(os.path.join(workspace, m.group(1).strip()))
+        if os.path.isdir(gitdir):
+            dirs.append(gitdir)
+            common = os.path.join(gitdir, "commondir")
+            if os.path.isfile(common):
+                with open(common, encoding="utf-8", errors="replace") as fh:
+                    rel = fh.read().strip()
+                commondir = os.path.normpath(os.path.join(gitdir, rel))
+                if os.path.isdir(commondir):
+                    dirs.append(commondir)
+    except OSError:
+        return dirs
+    return dirs
+
+
+def profile_text(workspace: str) -> str:
+    """Deny-writes-outside-allowlist profile. `(allow default)` keeps reads,
+    network, exec, signals open — v1 confines exactly one thing: where files can
+    be written. The allowlist is every place real commands legitimately write:
+    the workspace, POSIX and macOS temp roots, tool caches (uv/pip live under
+    ~/Library/Caches on macOS, not ~/.cache), and chad's state dir."""
+    home = os.path.expanduser("~")
+    ws = os.path.realpath(workspace)
+    write_paths = [ws]
+    if workspace != ws:
+        write_paths.append(workspace)
+    write_paths += _worktree_gitdirs(ws)
+    write_paths += [
+        "/tmp", "/private/tmp", "/var/tmp", "/private/var/tmp",
+        "/private/var/folders",              # $TMPDIR lives here on macOS
+        os.path.join(home, ".chad"),
+        os.path.join(home, ".cache"),
+        os.path.join(home, "Library", "Caches"),
+        os.path.join(home, ".local", "share", "uv"),
+        os.path.join(home, ".npm"),
+    ]
+    lines = ["(version 1)", "(allow default)", "(deny file-write*)",
+             "(allow file-write*"]
+    for p in write_paths:
+        lines.append(f'    (subpath "{_scheme_str(p)}")')
+    lines.append(f'    (literal "{_scheme_str(os.path.join(home, ".gitconfig"))}")')
+    for dev in ("/dev/null", "/dev/stdout", "/dev/stderr", "/dev/fd"):
+        lines.append(f'    (literal "{dev}")')
+    lines.append('    (regex #"^/dev/tty")')
+    lines.append(")")
+    return "\n".join(lines) + "\n"
+
+
+def _profile_path(workspace: str) -> str:
+    ws = os.path.realpath(workspace)
+    path = _profiles.get(ws)
+    if path and os.path.exists(path):
+        return path
+    fd, path = tempfile.mkstemp(prefix="chad-seatbelt-", suffix=".sb")
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(profile_text(ws))
+    _profiles[ws] = path
+    log.info("SEATBELT profile for %s -> %s", ws, path)
+    return path
+
+
+def wrap_argv(command: str) -> Optional[list]:
+    """The argv to spawn `command` sandboxed, or None to run it unconfined.
+    None whenever the lever is off, the executing agent is not in yolo mode, or
+    the platform can't do Seatbelt — tool_bash falls through to its normal
+    shell=True spawn, byte-identical behavior to before this module existed."""
+    if not levers.enabled("yolo_seatbelt"):
+        return None
+    if not _ctx["active"] or not probe():
+        return None
+    workspace = _ctx["workspace"] or os.getcwd()
+    try:
+        profile = _profile_path(workspace)
+    except OSError as e:
+        # No profile means no confinement; in yolo that is the unsafe direction,
+        # but killing every bash call is worse — log loudly and run unconfined.
+        log.warning("SEATBELT profile write failed (%s) — running unconfined", e)
+        return None
+    return [SANDBOX_EXEC, "-f", profile, "/bin/sh", "-c", command]

--- a/src/chad/seatbelt.py
+++ b/src/chad/seatbelt.py
@@ -22,6 +22,7 @@ confinement of the agent/mode that is actually executing.
 import logging
 import os
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -33,7 +34,7 @@ log = logging.getLogger("chad")
 
 SANDBOX_EXEC = "/usr/bin/sandbox-exec"
 
-# One-shot capability probe. Seatbelt profiles don't nest: when chad itself runs
+# One-shot enforcement probe. Seatbelt profiles don't nest: when chad itself runs
 # inside a sandbox (CI, a harness container, another agent's shell tool),
 # sandbox-exec fails to apply and would turn EVERY yolo bash call into an error.
 # Probe once per process; on failure run unconfined (logged) rather than broken.
@@ -68,23 +69,52 @@ def available() -> bool:
 
 
 def probe() -> bool:
-    """Can a sandbox actually be applied from this process? Cached per process."""
+    """Does a sandbox applied from this process actually ENFORCE? Cached per process.
+
+    Running `sandbox-exec` successfully proves nothing about confinement: a profile
+    that fails open (OS version drift, a malformed rule) would leave every yolo
+    command reported as confined while writing anywhere it likes — a boundary that
+    lies is worse than no boundary. So the probe exercises both directions of a
+    real deny/allow profile against a throwaway directory pair: the allowed write
+    must land AND the denied write must not. A denied write that lands fails the
+    probe loudly; either failure means yolo bash runs unconfined (and says so)
+    rather than confined-in-name-only."""
     global _probe_result
-    if _probe_result is None:
-        if not available():
-            _probe_result = False
-        else:
-            try:
-                r = subprocess.run(
-                    [SANDBOX_EXEC, "-p", "(version 1)(allow default)",
-                     "/usr/bin/true"],
-                    capture_output=True, timeout=10, check=False)
-                _probe_result = r.returncode == 0
-            except (OSError, subprocess.SubprocessError):
-                _probe_result = False
-            if not _probe_result:
-                log.warning("SEATBELT unavailable here (nested sandbox or missing "
-                            "support) — yolo bash runs unconfined")
+    if _probe_result is not None:
+        return _probe_result
+    if not available():
+        _probe_result = False
+        return False
+    _probe_result = False
+    leaked = False
+    try:
+        with tempfile.TemporaryDirectory(prefix="chad-sb-probe-") as tmp:
+            # Seatbelt matches the KERNEL's view of a path: $TMPDIR is a symlink
+            # (/var/folders -> /private/var/folders), and an allow rule written
+            # against the symlinked spelling silently denies everything under it.
+            root = os.path.realpath(tmp)
+            allowed = os.path.join(root, "allowed")
+            denied = os.path.join(root, "denied")
+            os.mkdir(allowed)
+            os.mkdir(denied)
+            prof = ("(version 1)(allow default)(deny file-write*)"
+                    f'(allow file-write* (subpath "{_scheme_str(allowed)}"))')
+            cmd = (f"printf ok > {shlex.quote(os.path.join(allowed, 'w'))}; "
+                   f"printf no > {shlex.quote(os.path.join(denied, 'w'))}")
+            subprocess.run([SANDBOX_EXEC, "-p", prof, "/bin/sh", "-c", cmd],
+                           capture_output=True, timeout=10, check=False)
+            leaked = os.path.isfile(os.path.join(denied, "w"))
+            _probe_result = (not leaked
+                             and os.path.isfile(os.path.join(allowed, "w")))
+    except (OSError, subprocess.SubprocessError):
+        _probe_result = False
+    if leaked:
+        log.error("SEATBELT profile FAILED to enforce (a write that must be denied "
+                  "landed) — refusing a confinement that would only be claimed; "
+                  "yolo bash runs unconfined")
+    elif not _probe_result:
+        log.warning("SEATBELT unavailable here (nested sandbox or missing "
+                    "support) — yolo bash runs unconfined")
     return _probe_result
 
 
@@ -129,13 +159,35 @@ def profile_text(workspace: str) -> str:
     network, exec, signals open — v1 confines exactly one thing: where files can
     be written. The allowlist is every place real commands legitimately write:
     the workspace, POSIX and macOS temp roots, tool caches (uv/pip live under
-    ~/Library/Caches on macOS, not ~/.cache), and chad's state dir."""
+    ~/Library/Caches on macOS, not ~/.cache), and chad's state dir.
+
+    Two carve-backs ride AFTER the allow block (the last matching Seatbelt rule
+    wins), because a writable root is not uniformly expendable:
+
+    * `~/.chad/checkpoints` — the shadow-repo undo history. It sits under the
+      allowed `~/.chad` subpath, so without its own deny a sandboxed command
+      could delete the very snapshots a user would reach for after a bad turn.
+      Only chad's own (never-sandboxed) process legitimately writes there, so
+      this deny is unconditional and costs real commands nothing.
+    * the workspace's git metadata (`.git`, and for a worktree checkout its
+      external gitdir + shared common dir) — gated by the `seatbelt_protect_git`
+      lever, its own opt-in tier rather than part of the base profile: it makes
+      project history un-destroyable from inside the sandbox (`rm -rf .git`
+      EPERMs), but any git command that writes — commit, add, checkout — fails
+      with it. Sized statically against 91,910 real session commands: at most
+      2.65% would EPERM (an upper bound — a clone/init into a subdirectory makes
+      a NESTED .git, which stays writable), concentrated in 14% of sessions.
+      With the tier off, worktree gitdirs stay on the ALLOW list, since every
+      git command writes through them."""
     home = os.path.expanduser("~")
     ws = os.path.realpath(workspace)
+    protect_git = levers.enabled("seatbelt_protect_git")
+    gitdirs = _worktree_gitdirs(ws)
     write_paths = [ws]
     if workspace != ws:
         write_paths.append(workspace)
-    write_paths += _worktree_gitdirs(ws)
+    if not protect_git:
+        write_paths += gitdirs
     write_paths += [
         "/tmp", "/private/tmp", "/var/tmp", "/private/var/tmp",
         "/private/var/folders",              # $TMPDIR lives here on macOS
@@ -154,18 +206,31 @@ def profile_text(workspace: str) -> str:
         lines.append(f'    (literal "{dev}")')
     lines.append('    (regex #"^/dev/tty")')
     lines.append(")")
+    deny_paths = [os.path.join(home, ".chad", "checkpoints")]
+    if protect_git:
+        deny_paths.append(os.path.join(ws, ".git"))
+        if workspace != ws:
+            deny_paths.append(os.path.join(workspace, ".git"))
+        deny_paths += gitdirs
+    lines.append("(deny file-write*")
+    for p in deny_paths:
+        lines.append(f'    (subpath "{_scheme_str(p)}")')
+    lines.append(")")
     return "\n".join(lines) + "\n"
 
 
 def _profile_path(workspace: str) -> str:
+    # Keyed on the git-protection tier as well as the workspace: the profile body
+    # differs, and lever state can change between calls within one process.
     ws = os.path.realpath(workspace)
-    path = _profiles.get(ws)
+    key = (ws, levers.enabled("seatbelt_protect_git"))
+    path = _profiles.get(key)
     if path and os.path.exists(path):
         return path
     fd, path = tempfile.mkstemp(prefix="chad-seatbelt-", suffix=".sb")
     with os.fdopen(fd, "w", encoding="utf-8") as fh:
         fh.write(profile_text(ws))
-    _profiles[ws] = path
+    _profiles[key] = path
     log.info("SEATBELT profile for %s -> %s", ws, path)
     return path
 

--- a/src/chad/tools.py
+++ b/src/chad/tools.py
@@ -276,6 +276,30 @@ def _bash_backgrounded(d: "_BgDrainer", timeout: int) -> str | None:
     return head + "\n" + _bash_headtail(partial) if partial else head
 
 
+# Environment variable names shaped like credentials, dropped from spawned shell
+# children when the bash_env_guard lever is on. Name-pattern only: values are never
+# inspected (a value test would itself be a secret-handling liability), and the
+# pattern is anchored at the end so AWS_SECRET_ACCESS_KEY, GITHUB_TOKEN, and
+# DB_PASSWORD match while PATH, TOKENIZERS_PARALLELISM, and friends pass through.
+_ENV_SECRET_RE = re.compile(
+    r"(?i)(TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?|API_?KEY|"
+    r"ACCESS_KEY(_ID)?|SECRET_KEY|PRIVATE_KEY)$")
+
+
+def _bash_env() -> dict | None:
+    """The environment for a spawned bash child: None (inherit the parent env
+    untouched — the default contract) unless the guard lever is on, in which case a
+    copy with credential-shaped names removed. A command that legitimately needs a
+    credential sees a clear absence, not a corrupted value."""
+    if not levers.enabled("bash_env_guard"):
+        return None
+    env = {k: v for k, v in os.environ.items() if not _ENV_SECRET_RE.search(k)}
+    dropped = len(os.environ) - len(env)
+    if dropped:
+        levers.fired("bash_env_guard", dropped=dropped)
+    return env
+
+
 def _bash_auto_background(command: str, timeout: int, should_stop) -> str:
     """tool_bash's timeout path when auto-background is armed. Mirrors the foreground
     loop exactly, except that a timeout hands the command off instead of killing it."""
@@ -284,7 +308,7 @@ def _bash_auto_background(command: str, timeout: int, should_stop) -> str:
         p = subprocess.Popen(argv if argv is not None else command,
                              shell=argv is None, stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT, text=True, errors="replace",
-                             start_new_session=True)
+                             start_new_session=True, env=_bash_env())
     except OSError as e:
         return f"[failed to launch: {e}]"
     d = _BgDrainer(p)
@@ -326,7 +350,7 @@ def tool_bash(command: str, timeout: int = 120, should_stop=None) -> str:
         p = subprocess.Popen(argv if argv is not None else command,
                              shell=argv is None, stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT, text=True, errors="replace",
-                             start_new_session=True)
+                             start_new_session=True, env=_bash_env())
     except OSError as e:
         return f"[failed to launch: {e}]"
     # Drain output on a helper thread (so large output can't deadlock the pipe)

--- a/src/chad/tools.py
+++ b/src/chad/tools.py
@@ -21,7 +21,7 @@ import threading
 import time
 from typing import Any
 
-from . import config, levers, lsp, repomap, symbols, syntaxgate
+from . import config, levers, lsp, repomap, seatbelt, symbols, syntaxgate
 from .ignore import IGNORE_DIRS, slash_wrapped
 
 # Directories never worth walking: huge, generated, or VCS internals. The canonical set
@@ -279,8 +279,10 @@ def _bash_backgrounded(d: "_BgDrainer", timeout: int) -> str | None:
 def _bash_auto_background(command: str, timeout: int, should_stop) -> str:
     """tool_bash's timeout path when auto-background is armed. Mirrors the foreground
     loop exactly, except that a timeout hands the command off instead of killing it."""
+    argv = seatbelt.wrap_argv(command)
     try:
-        p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE,
+        p = subprocess.Popen(argv if argv is not None else command,
+                             shell=argv is None, stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT, text=True, errors="replace",
                              start_new_session=True)
     except OSError as e:
@@ -308,18 +310,21 @@ def _bash_auto_background(command: str, timeout: int, should_stop) -> str:
         p.poll()
     if p.returncode not in (0, None):
         out = f"[exit {p.returncode}]\n{out}"
+    out = _seatbelt_note(argv, out)
     return _bash_headtail(out) if out else "[no output]"
 
 
 def tool_bash(command: str, timeout: int = 120, should_stop=None) -> str:
     if levers.enabled("bash_auto_background"):
         return _bash_auto_background(command, timeout, should_stop)
+    argv = seatbelt.wrap_argv(command)
     try:
         # errors="replace": text mode decodes strictly by default, so binary bytes in the
         # output (hexdump, `cat` on an archive) killed the reader thread mid-communicate —
         # the command's whole output AND its exit code vanished into a "[no output]" that
         # read as a quiet success (and could spoof the verify gate).
-        p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE,
+        p = subprocess.Popen(argv if argv is not None else command,
+                             shell=argv is None, stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT, text=True, errors="replace",
                              start_new_session=True)
     except OSError as e:
@@ -344,7 +349,19 @@ def tool_bash(command: str, timeout: int = 120, should_stop=None) -> str:
         p.poll()  # reconcile: a reader-thread death skips communicate()'s internal wait
     if p.returncode not in (0, None):
         out = f"[exit {p.returncode}]\n{out}"
+    out = _seatbelt_note(argv, out)
     return _bash_headtail(out) if out else "[no output]"
+
+
+def _seatbelt_note(argv, out: str) -> str:
+    """When a sandboxed command's output shows a write denial, say what happened
+    and what to do — a bare 'Operation not permitted' reads as a broken tool, and
+    a model that can't see the boundary will retry into it. Each detected denial
+    is exactly the event the lever exists to produce, so it fires here."""
+    if argv is None or seatbelt.DENIAL_MARKER not in out:
+        return out
+    levers.fired("yolo_seatbelt", denial=True)
+    return out + seatbelt.DENIAL_NOTE
 
 
 def _bash_killed(reason: str, partial: str | None) -> str:

--- a/src/chad/tui.py
+++ b/src/chad/tui.py
@@ -212,6 +212,8 @@ SLASH_COMMANDS = [
     ("/mcp trust", "trust this project's .mcp.json servers"),
     ("/mcp login", "authenticate an MCP server (OAuth)"),
     ("/compact", "reclaim context now"),
+    ("/undo", "revert files to the last edit checkpoint"),
+    ("/restore", "list edit checkpoints; /restore <hash> reverts to one"),
     ("/resume", "list recent sessions; /resume <n> forks one"),
     ("/reset", "clear the conversation + KV cache"),
     ("/clear", "clear the conversation + KV cache"),
@@ -1042,6 +1044,33 @@ class TUI:
                 self._emit("info", f"compacted context: {b:,}→{a:,} tokens"
                                    + (" (already lean)" if a >= b else ""))
             return False
+        if text == "/undo" or text == "/restore" or text.startswith("/restore "):
+            # Checkout mutates workspace files: refuse mid-turn for the same reason
+            # /compact does — the running turn is operating on those files.
+            if self._busy:
+                self._emit("info", "busy — try again once the current turn finishes.")
+                return False
+            from . import checkpoint, levers
+            ws = os.getcwd()
+            arg = text[len("/restore"):].strip() if text.startswith("/restore") else ""
+            if text == "/restore" and not arg:
+                rows = checkpoint.snapshots(ws)
+                if not rows:
+                    self._emit("info", "no checkpoints for this workspace yet — "
+                                       "snapshots are taken before file edits when the "
+                                       "edit_checkpoint lever is on (CHAD_ENABLE=edit_checkpoint)")
+                else:
+                    for h, when, label in rows:
+                        self._emit("info", f"  {h}  {when}  {label}")
+                    self._emit("info", "restore one with /restore <hash>")
+                return False
+            msg = checkpoint.restore(ws, arg or "HEAD")
+            # Restoring from an older session's snapshots is legal with the lever
+            # off, so only count the fire when this session's guard is actually on.
+            if msg.startswith("restored") and levers.enabled("edit_checkpoint"):
+                levers.fired("edit_checkpoint", restore=True)
+            self._emit("info", msg)
+            return False
         if text == "/resume" or text.startswith("/resume "):
             self._handle_resume(text[len("/resume"):].strip())
             return False
@@ -1084,7 +1113,7 @@ class TUI:
             self._emit("info", "shift-tab: cycle mode (normal/auto-accept edits/yolo/plan) "
                                "· esc/ctrl-c: "
                                "interrupt · /init /skills /mcp /mcp trust /mcp login <server> "
-                               "/resume /reset /clear /compact /model /mode /speech /accept /exit · !cmd shell · @path "
+                               "/resume /reset /clear /compact /undo /restore /model /mode /speech /accept /exit · !cmd shell · @path "
                                "attach · type while busy to steer the running turn "
                                "(applies after the current step) · plan ready: type to "
                                "steer, ctrl-g to accept")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,15 @@ def _levers_all_on(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _checkpoint_tmpdir(tmp_path, monkeypatch):
+    """Point edit-checkpoint shadow repos (checkpoint._history_root) at a per-test
+    tmp dir. The suite runs CHAD_ENABLE=all, so any test that drives run_turn
+    through a file-mutating tool takes a real snapshot — of the pytest CWD, into
+    the developer's ~/.chad, at ~300ms per shot — unless redirected here."""
+    monkeypatch.setenv("CHAD_CHECKPOINT_DIR", str(tmp_path / "checkpoints"))
+
+
+@pytest.fixture(autouse=True)
 def _spill_tmpdir(tmp_path, monkeypatch):
     """Point bash-output spills (tools._spill_bash) at a per-test tmp dir —
     any test that runs an oversized bash command would otherwise leave files in the

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,132 @@
+"""Shadow-git checkpoints (checkpoint.py): snapshot → mutate → restore round trips.
+
+Contract: the user's own .git is never opened or written; untracked-in-user-repo
+files ARE snapshotted (they're exactly what an edit can destroy); restore puts
+snapshotted content back but never deletes files created after the snapshot; every
+failure path returns a value instead of raising (an edit must not die because the
+checkpoint machinery hiccuped). The shadow lives under ~/.chad/history — pointed at
+a tmp HOME here so tests never touch the real one.
+"""
+import os
+import subprocess
+
+import pytest
+
+from chad import checkpoint
+
+
+@pytest.fixture(autouse=True)
+def _own_checkpoint_dir(tmp_path, monkeypatch):
+    # conftest already redirects CHAD_CHECKPOINT_DIR for the whole suite; pin it
+    # here too so this file stands alone (its assertions depend on an empty root).
+    monkeypatch.setenv("CHAD_CHECKPOINT_DIR", str(tmp_path / "ckpt"))
+
+
+@pytest.fixture()
+def ws(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    (d / "a.py").write_text("A1\n")
+    (d / "b.py").write_text("B1\n")
+    return d
+
+
+def test_snapshot_returns_hash_and_shadow_is_outside_ws(ws):
+    ref = checkpoint.snapshot(str(ws), "before edit a.py")
+    assert ref
+    assert not (ws / ".git").exists()
+    assert not checkpoint.shadow_dir(str(ws)).startswith(str(ws))
+    assert checkpoint.shadow_dir(str(ws)).startswith(
+        os.environ["CHAD_CHECKPOINT_DIR"])
+
+
+def test_round_trip_restores_content(ws):
+    checkpoint.snapshot(str(ws), "before edit")
+    (ws / "a.py").write_text("A2 clobbered\n")
+    (ws / "b.py").unlink()
+    msg = checkpoint.restore(str(ws))
+    assert msg.startswith("restored")
+    assert (ws / "a.py").read_text() == "A1\n"
+    assert (ws / "b.py").read_text() == "B1\n"
+
+
+def test_restore_leaves_files_created_after_snapshot(ws):
+    checkpoint.snapshot(str(ws), "s1")
+    (ws / "new.py").write_text("created later\n")
+    msg = checkpoint.restore(str(ws))
+    assert msg.startswith("restored")
+    assert (ws / "new.py").read_text() == "created later\n"
+
+
+def test_restore_to_named_earlier_snapshot(ws):
+    checkpoint.snapshot(str(ws), "s1")
+    (ws / "a.py").write_text("A2\n")
+    first = checkpoint.snapshots(str(ws))[-1][0]
+    checkpoint.snapshot(str(ws), "s2")
+    (ws / "a.py").write_text("A3\n")
+    msg = checkpoint.restore(str(ws), first)
+    assert msg.startswith("restored")
+    assert (ws / "a.py").read_text() == "A1\n"
+
+
+def test_unchanged_tree_snapshot_returns_prior_hash(ws):
+    r1 = checkpoint.snapshot(str(ws), "s1")
+    r2 = checkpoint.snapshot(str(ws), "s2 nothing changed")
+    assert r1 == r2
+
+
+def test_snapshots_listing_newest_first(ws):
+    checkpoint.snapshot(str(ws), "first")
+    (ws / "a.py").write_text("A2\n")
+    checkpoint.snapshot(str(ws), "second")
+    rows = checkpoint.snapshots(str(ws))
+    assert [r[2] for r in rows] == ["second", "first"]
+
+
+def test_user_git_repo_untouched(ws):
+    subprocess.run(["git", "init", "-q", str(ws)], check=True)
+    subprocess.run(["git", "-C", str(ws), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(ws), "-c", "user.email=u@u", "-c",
+                    "user.name=u", "-c", "commit.gpgsign=false",
+                    "commit", "-qm", "user commit"], check=True)
+    head_before = subprocess.run(["git", "-C", str(ws), "rev-parse", "HEAD"],
+                                 capture_output=True, text=True, check=True).stdout
+    checkpoint.snapshot(str(ws), "shadow snap")
+    (ws / "a.py").write_text("A2\n")
+    checkpoint.restore(str(ws))
+    head_after = subprocess.run(["git", "-C", str(ws), "rev-parse", "HEAD"],
+                                capture_output=True, text=True, check=True).stdout
+    log = subprocess.run(["git", "-C", str(ws), "log", "--format=%s"],
+                         capture_output=True, text=True, check=True).stdout
+    assert head_before == head_after
+    assert "shadow snap" not in log
+
+
+def test_default_excludes_keep_junk_out(ws):
+    (ws / ".venv").mkdir()
+    (ws / ".venv" / "huge.bin").write_text("x" * 10)
+    (ws / "__pycache__").mkdir()
+    (ws / "__pycache__" / "a.pyc").write_text("x")
+    checkpoint.snapshot(str(ws), "s1")
+    files = subprocess.run(
+        ["git", "--git-dir", checkpoint.shadow_dir(str(ws)), "ls-tree", "-r",
+         "--name-only", "HEAD"], capture_output=True, text=True, check=False).stdout
+    assert ".venv" not in files and "__pycache__" not in files
+    assert "a.py" in files
+
+
+def test_restore_without_snapshots_is_a_message_not_a_crash(ws):
+    msg = checkpoint.restore(str(ws))
+    assert "no checkpoints" in msg
+
+
+def test_restore_unknown_ref_is_a_message(ws):
+    checkpoint.snapshot(str(ws), "s1")
+    msg = checkpoint.restore(str(ws), "deadbeef")
+    assert "no checkpoint named" in msg
+
+
+def test_snapshot_failure_returns_none(ws, monkeypatch):
+    monkeypatch.setattr(checkpoint, "shadow_dir",
+                        lambda _ws: "/dev/null/not/a/dir/shadow.git")
+    assert checkpoint.snapshot(str(ws), "s") is None

--- a/tests/test_lever_bite.py
+++ b/tests/test_lever_bite.py
@@ -881,6 +881,53 @@ def test_bash_read_skeleton_bite(tmp_path, monkeypatch):
 
 # === the coverage contract =================================================
 
+# === group "safety" ===============================================================
+
+def test_yolo_seatbelt_bite(monkeypatch, tmp_path):
+    """ON, a yolo-context bash command gets a sandbox-exec argv; OFF, wrap_argv
+    declines and the spawn is the plain shell=True path. Platform capability is
+    forced so the pair is about the LEVER, not the host."""
+    from chad import seatbelt
+    n = bite("yolo_seatbelt")
+    monkeypatch.setattr(seatbelt, "probe", lambda: True)
+    monkeypatch.setattr(seatbelt, "_profiles", {})
+    seatbelt.set_context(True, str(tmp_path))
+    try:
+        on(monkeypatch)
+        argv = seatbelt.wrap_argv("true")
+        assert argv is not None and argv[0] == seatbelt.SANDBOX_EXEC
+        off(monkeypatch, n)
+        assert seatbelt.wrap_argv("true") is None
+    finally:
+        seatbelt.set_context(False, None)
+
+
+def test_edit_checkpoint_bite(monkeypatch, tmp_path):
+    """ON, a write dispatched through the real run_turn leaves a shadow snapshot;
+    OFF, the same turn leaves none. Driven end to end because the guard lives at
+    the agent's dispatch site, not inside the tool."""
+    from chad import checkpoint
+    from test_agent_e2e import _agent, _tool_call
+    n = bite("edit_checkpoint")
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "existing.txt").write_text("pre-existing state worth protecting\n")
+    monkeypatch.chdir(ws)
+    quiet = "done_spec_recheck,done_audit"  # keep the scripted turn to write→done
+
+    monkeypatch.setenv("CHAD_CHECKPOINT_DIR", str(tmp_path / "on"))
+    monkeypatch.setenv("CHAD_DISABLE", quiet)
+    script = [_tool_call("write", path=str(ws / "f.txt"), content="x\n"),
+              _tool_call("done", summary="wrote")]
+    _agent(list(script), max_steps=6).run_turn("write f.txt")
+    assert checkpoint.snapshots(str(ws)), "ON: the write should have snapshotted"
+
+    monkeypatch.setenv("CHAD_CHECKPOINT_DIR", str(tmp_path / "off"))
+    monkeypatch.setenv("CHAD_DISABLE", quiet + "," + n)
+    _agent(list(script), max_steps=6).run_turn("write f.txt")
+    assert checkpoint.snapshots(str(ws)) == [], "OFF: no snapshot may be taken"
+
+
 def test_every_registered_lever_has_a_bite_test():
     """A lever with no minimal on/off pair is a lever that might not bite. Ablating it
     would report 'no measured effect' and the fix would be deleted on that evidence."""

--- a/tests/test_lever_bite.py
+++ b/tests/test_lever_bite.py
@@ -928,6 +928,30 @@ def test_edit_checkpoint_bite(monkeypatch, tmp_path):
     assert checkpoint.snapshots(str(ws)) == [], "OFF: no snapshot may be taken"
 
 
+def test_seatbelt_protect_git_bite(monkeypatch, tmp_path):
+    """ON, the workspace's .git is carved back OUT of the writable allowlist in the
+    generated profile (a trailing deny, which wins in Seatbelt); OFF, no such deny."""
+    from chad import seatbelt
+    n = bite("seatbelt_protect_git")
+    dotgit = f'(subpath "{tmp_path.resolve() / ".git"}")'
+    on(monkeypatch)
+    assert dotgit in seatbelt.profile_text(str(tmp_path))
+    off(monkeypatch, n)
+    assert dotgit not in seatbelt.profile_text(str(tmp_path))
+
+
+def test_bash_env_guard_bite(monkeypatch):
+    """ON, credential-shaped names are dropped from the env copy handed to the
+    spawned shell; OFF, the child inherits the parent environment untouched."""
+    n = bite("bash_env_guard")
+    monkeypatch.setenv("SOME_API_KEY", "k")
+    on(monkeypatch)
+    env = tools._bash_env()
+    assert env is not None and "SOME_API_KEY" not in env
+    off(monkeypatch, n)
+    assert tools._bash_env() is None
+
+
 def test_every_registered_lever_has_a_bite_test():
     """A lever with no minimal on/off pair is a lever that might not bite. Ablating it
     would report 'no measured effect' and the fix would be deleted on that evidence."""

--- a/tests/test_seatbelt.py
+++ b/tests/test_seatbelt.py
@@ -89,22 +89,168 @@ def test_profile_escapes_scheme_metachars(tmp_path):
     assert 'we"ird")' not in text
 
 
-def test_profile_worktree_gitdir_carveout(tmp_path):
+def _split_at_deny_tail(text: str):
+    """(allow-and-before, trailing deny block) — the deny block that carves paths
+    back OUT of the writable allowlist sits last, because the last matching
+    Seatbelt rule wins."""
+    i = text.rindex("(deny file-write*")
+    return text[:i], text[i:]
+
+
+def _worktree_fixture(tmp_path):
     ws = tmp_path / "wt"
     ws.mkdir()
     gitdir = tmp_path / "main" / ".git" / "worktrees" / "wt"
     gitdir.mkdir(parents=True)
     (gitdir / "commondir").write_text("../..\n")
     (ws / ".git").write_text(f"gitdir: {gitdir}\n")
-    text = seatbelt.profile_text(str(ws))
-    assert str(gitdir.resolve()) in text
-    common = (gitdir / "../..").resolve()
-    assert str(common) in text
+    return ws, gitdir.resolve(), (gitdir / "../..").resolve()
+
+
+def test_profile_worktree_gitdir_carveout(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHAD_DISABLE", "seatbelt_protect_git")
+    ws, gitdir, common = _worktree_fixture(tmp_path)
+    head, tail = _split_at_deny_tail(seatbelt.profile_text(str(ws)))
+    assert str(gitdir) in head and str(common) in head
+    assert str(gitdir) not in tail and str(common) not in tail
+
+
+def test_profile_protect_git_flips_worktree_gitdirs_to_deny(tmp_path):
+    # the suite runs CHAD_ENABLE=all, so the protection tier is on here
+    ws, gitdir, common = _worktree_fixture(tmp_path)
+    head, tail = _split_at_deny_tail(seatbelt.profile_text(str(ws)))
+    assert str(gitdir) in tail and str(common) in tail
+    assert str(gitdir) not in head and str(common) not in head
+
+
+def test_profile_protect_git_denies_workspace_dotgit(tmp_path):
+    _head, tail = _split_at_deny_tail(seatbelt.profile_text(str(tmp_path)))
+    ws = tmp_path.resolve()
+    assert f'(subpath "{ws / ".git"}")' in tail
+
+
+def test_profile_checkpoints_denied_even_without_git_tier(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHAD_DISABLE", "seatbelt_protect_git")
+    text = seatbelt.profile_text(str(tmp_path))
+    head, tail = _split_at_deny_tail(text)
+    ckpt = os.path.join(os.path.expanduser("~"), ".chad", "checkpoints")
+    assert f'(subpath "{ckpt}")' in tail
+    assert "/.git" not in tail
+    # ~/.chad itself stays on the allowlist; only the undo history is carved out
+    assert os.path.join(os.path.expanduser("~"), ".chad") in head
+
+
+def test_profile_cache_distinguishes_git_tier(monkeypatch, tmp_path):
+    _force_capable(monkeypatch)
+    seatbelt.set_context(True, str(tmp_path))
+    with_tier = seatbelt.wrap_argv("true")[2]
+    monkeypatch.setenv("CHAD_DISABLE", "seatbelt_protect_git")
+    without_tier = seatbelt.wrap_argv("true")[2]
+    assert with_tier != without_tier
+    with open(with_tier, encoding="utf-8") as fh:
+        assert str(tmp_path.resolve() / ".git") in fh.read()
+    with open(without_tier, encoding="utf-8") as fh:
+        assert str(tmp_path.resolve() / ".git") not in fh.read()
 
 
 def test_profile_plain_repo_no_carveout(tmp_path):
     (tmp_path / ".git").mkdir()  # normal repo: .git is a dir, no pointer to chase
     assert seatbelt._worktree_gitdirs(str(tmp_path)) == []
+
+
+# -- enforcement probe --------------------------------------------------------
+# probe() must prove the profile DENIES, not merely that sandbox-exec runs: a
+# profile that fails open would otherwise report confinement it does not have.
+
+_real_run = subprocess.run
+
+
+def _probe_with(monkeypatch, fake_run):
+    monkeypatch.setattr(seatbelt, "available", lambda: True)
+    monkeypatch.setattr(seatbelt.subprocess, "run", fake_run)
+    return seatbelt.probe()
+
+
+def test_probe_rejects_non_enforcing_sandbox(monkeypatch, caplog):
+    """sandbox-exec runs the command fine but enforces nothing (both writes land):
+    the probe must come back False, loudly — this is the fail-open case."""
+    def fake(argv, **kw):
+        return _real_run(argv[-3:], capture_output=True, check=False)
+    with caplog.at_level("ERROR", logger="chad"):
+        assert _probe_with(monkeypatch, fake) is False
+    assert any("FAILED to enforce" in r.getMessage() for r in caplog.records)
+
+
+def test_probe_rejects_sandbox_that_cannot_run(monkeypatch):
+    """Nothing executes at all (nested sandbox): neither write lands -> False."""
+    def fake(argv, **kw):
+        return subprocess.CompletedProcess(argv, 1)
+    assert _probe_with(monkeypatch, fake) is False
+
+
+def test_probe_accepts_enforcing_sandbox(monkeypatch):
+    """The allowed write lands and the denied one does not -> True. The fake
+    simulates enforcement by executing only the allowed half of the command."""
+    def fake(argv, **kw):
+        return _real_run(["/bin/sh", "-c", argv[-1].split(";")[0]],
+                         capture_output=True, check=False)
+    assert _probe_with(monkeypatch, fake) is True
+
+
+def test_probe_result_is_cached(monkeypatch):
+    calls = []
+    def fake(argv, **kw):
+        calls.append(argv)
+        return _real_run(["/bin/sh", "-c", argv[-1].split(";")[0]],
+                         capture_output=True, check=False)
+    assert _probe_with(monkeypatch, fake) is True
+    assert seatbelt.probe() is True
+    assert len(calls) == 1
+
+
+# -- the spawned shell's environment (bash_env_guard) -------------------------
+
+def test_bash_env_strips_credential_shaped_names(monkeypatch):
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "k")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "k")
+    monkeypatch.setenv("GITHUB_TOKEN", "k")
+    monkeypatch.setenv("MY_DB_PASSWORD", "k")
+    monkeypatch.setenv("SOME_CLIENT_SECRET", "k")
+    monkeypatch.setenv("TOKEN_COUNT", "5")            # TOKEN not at the end: keep
+    monkeypatch.setenv("TOKENIZERS_PARALLELISM", "1")  # likewise
+    env = tools._bash_env()
+    assert env is not None
+    for gone in ("AWS_SECRET_ACCESS_KEY", "AWS_ACCESS_KEY_ID", "GITHUB_TOKEN",
+                 "MY_DB_PASSWORD", "SOME_CLIENT_SECRET"):
+        assert gone not in env
+    for kept in ("PATH", "TOKEN_COUNT", "TOKENIZERS_PARALLELISM"):
+        assert kept in env
+
+
+def test_bash_env_off_means_inherit(monkeypatch):
+    monkeypatch.setenv("CHAD_DISABLE", "bash_env_guard")
+    assert tools._bash_env() is None
+
+
+def test_bash_env_guard_fires_only_when_something_dropped(monkeypatch):
+    for k in list(os.environ):
+        if tools._ENV_SECRET_RE.search(k):
+            monkeypatch.delenv(k)
+    before = levers.fire_counts().get("bash_env_guard", 0)
+    assert tools._bash_env() is not None
+    assert levers.fire_counts().get("bash_env_guard", 0) == before
+    monkeypatch.setenv("SOME_API_KEY", "k")
+    tools._bash_env()
+    assert levers.fire_counts().get("bash_env_guard", 0) == before + 1
+
+
+def test_bash_env_guard_end_to_end(monkeypatch):
+    seatbelt.set_context(False, None)
+    monkeypatch.setenv("SOME_API_KEY", "sekrit-value")
+    monkeypatch.setenv("HARMLESS_SETTING", "visible-value")
+    out = tools.tool_bash("printenv SOME_API_KEY; printenv HARMLESS_SETTING")
+    assert "sekrit-value" not in out
+    assert "visible-value" in out
 
 
 # -- the tool_bash seam -------------------------------------------------------
@@ -147,10 +293,11 @@ def test_unwrapped_denial_output_gets_no_note(monkeypatch):
 
 # -- real sandbox e2e (darwin only, skipped wherever Seatbelt can't apply) -----
 
-_can_sandbox = (sys.platform == "darwin" and os.path.exists(seatbelt.SANDBOX_EXEC)
-                and subprocess.run([seatbelt.SANDBOX_EXEC, "-p",
-                                    "(version 1)(allow default)", "/usr/bin/true"],
-                                   capture_output=True, check=False).returncode == 0)
+# Gate on the real enforcement probe, not a permissive-profile smoke test: inside a
+# CI/harness sandbox a permissive profile can still apply while a deny profile fails
+# open — exactly the environment where these tests must skip, not fail.
+_can_sandbox = seatbelt.probe()
+seatbelt._probe_result = None  # leave module state pristine for the tests above
 
 
 @pytest.mark.skipif(not _can_sandbox, reason="Seatbelt cannot apply here")
@@ -169,3 +316,22 @@ def test_e2e_denies_outside_write_allows_inside(tmp_path, monkeypatch):
     finally:
         if os.path.exists(probe):  # belt failed: don't leave droppings
             os.unlink(probe)
+
+
+@pytest.mark.skipif(not _can_sandbox, reason="Seatbelt cannot apply here")
+def test_e2e_enforcement_probe_green():
+    assert seatbelt.probe() is True
+
+
+@pytest.mark.skipif(not _can_sandbox, reason="Seatbelt cannot apply here")
+def test_e2e_protect_git_denies_gitdir_write(tmp_path):
+    (tmp_path / ".git").mkdir()
+    seatbelt.set_context(True, str(tmp_path))
+    argv = seatbelt.wrap_argv(f"touch {tmp_path}/.git/droppings")
+    r = subprocess.run(argv, capture_output=True, text=True, check=False)
+    assert r.returncode != 0
+    assert not (tmp_path / ".git" / "droppings").exists()
+    # the workspace around it stays writable
+    argv = seatbelt.wrap_argv(f"echo ok > {tmp_path}/normal.txt")
+    r = subprocess.run(argv, capture_output=True, text=True, check=False)
+    assert r.returncode == 0 and (tmp_path / "normal.txt").read_text().strip() == "ok"

--- a/tests/test_seatbelt.py
+++ b/tests/test_seatbelt.py
@@ -1,0 +1,171 @@
+"""Seatbelt confinement for yolo-mode bash (seatbelt.py + the tool_bash seam).
+
+The contract under test: wrapping happens ONLY when all four gates agree (lever on,
+executing agent in yolo mode, platform capable, probe green); when any gate says no,
+tool_bash's spawn is byte-identical to the pre-seatbelt behavior. The profile is a
+deny-writes-outside-allowlist; the note appended on a detected denial is what keeps
+the model from retrying into the wall. Real sandbox application is exercised in the
+darwin-gated e2e at the bottom; everything else forces the gates so the suite passes
+on any platform (and inside CI/test sandboxes, where Seatbelt cannot nest).
+"""
+import os
+import subprocess
+import sys
+
+import pytest
+
+from chad import levers, seatbelt, tools
+
+
+@pytest.fixture(autouse=True)
+def _reset_seatbelt(monkeypatch):
+    monkeypatch.setattr(seatbelt, "_ctx", {"active": False, "workspace": None})
+    monkeypatch.setattr(seatbelt, "_profiles", {})
+    monkeypatch.setattr(seatbelt, "_probe_result", None)
+
+
+def _force_capable(monkeypatch, ok=True):
+    monkeypatch.setattr(seatbelt, "probe", lambda: ok)
+
+
+# -- wrap gating --------------------------------------------------------------
+
+def test_no_wrap_when_lever_off(monkeypatch):
+    monkeypatch.setenv("CHAD_DISABLE", "yolo_seatbelt")
+    _force_capable(monkeypatch)
+    seatbelt.set_context(True, os.getcwd())
+    assert seatbelt.wrap_argv("echo hi") is None
+
+
+def test_no_wrap_outside_yolo_context(monkeypatch):
+    _force_capable(monkeypatch)
+    seatbelt.set_context(False, None)
+    assert seatbelt.wrap_argv("echo hi") is None
+
+
+def test_no_wrap_when_probe_fails(monkeypatch):
+    _force_capable(monkeypatch, ok=False)
+    seatbelt.set_context(True, os.getcwd())
+    assert seatbelt.wrap_argv("echo hi") is None
+
+
+def test_wrap_argv_shape(monkeypatch, tmp_path):
+    _force_capable(monkeypatch)
+    seatbelt.set_context(True, str(tmp_path))
+    argv = seatbelt.wrap_argv("echo hi > f.txt")
+    assert argv is not None
+    assert argv[0] == seatbelt.SANDBOX_EXEC and argv[1] == "-f"
+    assert argv[3:] == ["/bin/sh", "-c", "echo hi > f.txt"]
+    with open(argv[2], encoding="utf-8") as fh:
+        assert str(tmp_path.resolve()) in fh.read()
+
+
+def test_profile_cached_per_workspace(monkeypatch, tmp_path):
+    _force_capable(monkeypatch)
+    seatbelt.set_context(True, str(tmp_path))
+    a = seatbelt.wrap_argv("true")[2]
+    b = seatbelt.wrap_argv("false")[2]
+    assert a == b
+
+
+# -- profile content ----------------------------------------------------------
+
+def test_profile_denies_by_default_and_allows_workspace(tmp_path):
+    text = seatbelt.profile_text(str(tmp_path))
+    assert "(deny file-write*)" in text
+    assert f'(subpath "{tmp_path.resolve()}")' in text
+    assert "(allow default)" in text
+    # temp + cache roots a real command stream needs (uv/pip cache on macOS
+    # lives under ~/Library/Caches, not ~/.cache)
+    for needle in ("/private/var/folders", "Library/Caches", ".chad"):
+        assert needle in text
+
+
+def test_profile_escapes_scheme_metachars(tmp_path):
+    evil = tmp_path / 'we"ird'
+    evil.mkdir()
+    text = seatbelt.profile_text(str(evil))
+    assert 'we\\"ird' in text
+    assert 'we"ird")' not in text
+
+
+def test_profile_worktree_gitdir_carveout(tmp_path):
+    ws = tmp_path / "wt"
+    ws.mkdir()
+    gitdir = tmp_path / "main" / ".git" / "worktrees" / "wt"
+    gitdir.mkdir(parents=True)
+    (gitdir / "commondir").write_text("../..\n")
+    (ws / ".git").write_text(f"gitdir: {gitdir}\n")
+    text = seatbelt.profile_text(str(ws))
+    assert str(gitdir.resolve()) in text
+    common = (gitdir / "../..").resolve()
+    assert str(common) in text
+
+
+def test_profile_plain_repo_no_carveout(tmp_path):
+    (tmp_path / ".git").mkdir()  # normal repo: .git is a dir, no pointer to chase
+    assert seatbelt._worktree_gitdirs(str(tmp_path)) == []
+
+
+# -- the tool_bash seam -------------------------------------------------------
+
+def test_tool_bash_unwrapped_runs_plain_shell(monkeypatch):
+    seatbelt.set_context(False, None)
+    out = tools.tool_bash("echo plain")
+    assert "plain" in out
+
+
+def test_tool_bash_denial_note_and_fire(monkeypatch):
+    """A wrapped command whose output shows the EPERM marker gets the explanatory
+    note appended and fires the lever exactly once."""
+    fake = ["/bin/sh", "-c", "echo 'x: Operation not permitted'; exit 1"]
+    monkeypatch.setattr(seatbelt, "wrap_argv", lambda cmd: fake)
+    before = levers.fire_counts().get("yolo_seatbelt", 0)
+    out = tools.tool_bash("anything")
+    assert "Operation not permitted" in out
+    assert "seatbelt:" in out
+    assert levers.fire_counts().get("yolo_seatbelt", 0) == before + 1
+
+
+def test_tool_bash_wrapped_clean_run_no_note(monkeypatch):
+    fake = ["/bin/sh", "-c", "echo all good"]
+    monkeypatch.setattr(seatbelt, "wrap_argv", lambda cmd: fake)
+    before = levers.fire_counts().get("yolo_seatbelt", 0)
+    out = tools.tool_bash("anything")
+    assert "all good" in out
+    assert "seatbelt:" not in out
+    assert levers.fire_counts().get("yolo_seatbelt", 0) == before
+
+
+def test_unwrapped_denial_output_gets_no_note(monkeypatch):
+    """'Operation not permitted' from an UNSANDBOXED command (plain EPERM) must not
+    be blamed on the seatbelt."""
+    seatbelt.set_context(False, None)
+    out = tools.tool_bash("echo 'y: Operation not permitted'")
+    assert "seatbelt:" not in out
+
+
+# -- real sandbox e2e (darwin only, skipped wherever Seatbelt can't apply) -----
+
+_can_sandbox = (sys.platform == "darwin" and os.path.exists(seatbelt.SANDBOX_EXEC)
+                and subprocess.run([seatbelt.SANDBOX_EXEC, "-p",
+                                    "(version 1)(allow default)", "/usr/bin/true"],
+                                   capture_output=True, check=False).returncode == 0)
+
+
+@pytest.mark.skipif(not _can_sandbox, reason="Seatbelt cannot apply here")
+def test_e2e_denies_outside_write_allows_inside(tmp_path, monkeypatch):
+    seatbelt.set_context(True, str(tmp_path))
+    argv = seatbelt.wrap_argv(f"echo ok > {tmp_path}/in.txt")
+    r = subprocess.run(argv, capture_output=True, text=True, check=False)
+    assert r.returncode == 0 and (tmp_path / "in.txt").read_text().strip() == "ok"
+
+    probe = os.path.expanduser("~/chad_seatbelt_test_probe")
+    argv = seatbelt.wrap_argv(f"touch {probe}")
+    r = subprocess.run(argv, capture_output=True, text=True, check=False)
+    try:
+        assert r.returncode != 0
+        assert not os.path.exists(probe)
+    finally:
+        if os.path.exists(probe):  # belt failed: don't leave droppings
+            os.unlink(probe)

--- a/tests/test_seatbelt.py
+++ b/tests/test_seatbelt.py
@@ -10,7 +10,6 @@ on any platform (and inside CI/test sandboxes, where Seatbelt cannot nest).
 """
 import os
 import subprocess
-import sys
 
 import pytest
 

--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,7 @@ wheels = [
 
 [[package]]
 name = "chad-code"
-version = "1.11.0"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },


### PR DESCRIPTION
- **Sandbox hardening — the confinement must prove itself before it may be
  claimed:**
  - `yolo_seatbelt`'s startup probe now checks **enforcement in both
    directions** against a throwaway directory pair: the allowed write must
    land AND the denied write must not. The old probe only proved
    `sandbox-exec` could run a permissive profile — a profile failing open
    (OS drift, a malformed rule) would have reported confinement it did not
    have, the worst failure a safety lever can have. A denied write that
    lands now refuses the sandbox with a loud log; either failure runs
    unconfined and says so. (The probe promptly caught a real member of this
    class: an allow rule written against the `$TMPDIR` symlink spelling that
    Seatbelt, matching the kernel's real path, silently denied.)
  - The undo history (`~/.chad/checkpoints`, the `edit_checkpoint` shadow
    repo) is now **write-denied inside the sandbox**, closing the gap where
    it was reachable through the allowed `~/.chad` subpath — a sandboxed
    command could previously delete the very snapshots `/undo` restores
    from. Costs real commands nothing: only chad's own never-sandboxed
    process writes there.
- **Two new "safety" levers (default OFF):**
  - `seatbelt_protect_git` — opt-in tier on top of `yolo_seatbelt`: the
    workspace's git metadata (`.git`, and a worktree's external gitdir +
    common dir) becomes write-denied inside the otherwise-writable
    workspace, so an unreviewed command cannot `rm -rf .git` the project's
    history. The cost is real — every `.git`-writing git command (commit,
    add, checkout) EPERMs, sized statically at ≤2.65% of 91,910 real session
    commands, concentrated in 14% of sessions — which is why it is its own
    lever rather than part of the base profile.
  - `bash_env_guard` — spawned bash children get a filtered copy of the
    environment: variable names shaped like credentials (`…_TOKEN`,
    `…_SECRET`, `…_PASSWORD`, `…_API_KEY`, `…_ACCESS_KEY`, `…_PRIVATE_KEY`)
    are dropped, name-pattern only, values never read. A filesystem sandbox
    that still hands every command the operator's cloud keys is a half-closed
    boundary; commands that legitimately need a credential need the lever
    off (it defaults off, preserving inherit-all).
- **Two new "safety" levers (default OFF, like everything since 1.10.0) —
  blast-radius containment for unattended mutation:**
  - `yolo_seatbelt` — in yolo mode on macOS, each bash command's shell child
    runs under a Seatbelt profile (`sandbox-exec`) that denies file writes
    outside the workspace, temp dirs, tool caches, and `~/.chad`. Reads,
    network, and exec stay open, and the model process itself is never
    sandboxed — only the spawned shell. A detected denial gets a one-line
    explanation appended to the tool result so the model routes around the
    boundary instead of retrying into it. Environments where Seatbelt can't
    apply (CI, nested sandboxes) are probed once and run unconfined.
    Sized against 91,910 real session commands: 94.3% write only inside the
    allowlist; the denials are the system-admin writes the sandbox exists for.
  - `edit_checkpoint` — before a file-mutating tool lands, the workspace is
    committed to a shadow git repo under `~/.chad/checkpoints` (the project's
    own `.git` is never touched, written, or required to exist). New TUI
    commands: `/undo` reverts files to the last checkpoint, `/restore` lists
    checkpoints and reverts to a chosen one. Restores put snapshotted content
    back but never delete files created since — deleting is exactly the blast
    radius this lever contains. Snapshot cost measured at ~56ms per edit on a
    167-file repo (~84ms at 3,000 files).
