### PR TITLE
release/1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 Notable, user-visible changes.
 
+## [1.13.0] — 2026-08-10
+
+- **Per-step generation cap raised 8192 → 32768** (`CHAD_MAX_GEN_TOKENS`
+  overrides it): 8192 fixed the old truncated-write bug but introduced its
+  own loss class — on hard problems a long chain of thought can pin the cap
+  while still inside `<think>`, so the step ends as discarded reasoning with
+  no action and the next step re-derives from scratch. Trace measurement:
+  2% of steps pinned the cap, 82% of those mid-think, and a failing trial
+  was 2.75× more likely to contain one; an uncapped run of the same model
+  almost never exceeds 8192 on its own (p99 ~4.7k), yet the rare long
+  thought that does run completes real work when allowed to finish. The cap
+  stays as a backstop against non-repetitive runaway garble — literal decode
+  loops remain the repeat guard's job.
+- **New lever: `verification_matrix` (default OFF).** After ~8 exploratory
+  bash steps since the last landed change — *including after an edit has
+  landed*, the case `investigation_gate` cannot see, since it freezes the
+  moment any edit lands — the turn is pulled into a bounded verification
+  phase. It receives the task's own requirement lines (reusing the same
+  extractor `done_audit` runs, so the rows are the real predicates, not a
+  paraphrase) and must close each by exactly one of: (a) causal evidence
+  from a real run through the public path — a snapshot, a self-authored
+  "PASS", "no error", or a check built from the same assumption as the code
+  do not count — or (b) an explicit "unverified" note. That single rule both
+  bounds the loop (a finite checklist has a terminal state) and blocks
+  false-done; the honest-unverified escape is load-bearing, letting a turn
+  finish a genuinely unverifiable requirement instead of thrashing on it.
+  Re-arms up to 6 times per turn and never says a bare "call `done`", so
+  `done_audit` still guards the actual completion. Targets the measured #1
+  loss class: 69% of failing trials never called `done`, running a long tail
+  of exploratory bash (median 39 commands vs 12 on passes) around the same
+  edits a passing trial makes, until the step cap killed them.
+
 ## [1.12.0] — 2026-08-07
 
 - **Sandbox hardening — the confinement must prove itself before it may be

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # import name, and command name are independent. `uvx chad-code` runs the alias
 # script added under [project.scripts].
 name = "chad-code"
-version = "1.12.0"
+version = "1.13.0"
 description = "Local MLX-backed, Claude-Code-style coding agent (Apple Silicon, Ornith 35B/9B)"
 readme = "README.md"
 license = "MIT"

--- a/src/chad/__init__.py
+++ b/src/chad/__init__.py
@@ -4,7 +4,7 @@ A flat collection of cooperating modules behind one console script (``chad``):
 the inference engine, the tool layer, the agent loop, and the terminal UI.
 """
 
-__version__ = "1.12.0"
+__version__ = "1.13.0"
 
 # chad sets no MLX_* runtime vars. MLX_METAL_FAST_SYNCH, MLX_MAX_OPS_PER_BUFFER
 # and MLX_MAX_MB_PER_BUFFER were each measured end-to-end on the 35B and every

--- a/src/chad/agent.py
+++ b/src/chad/agent.py
@@ -862,6 +862,10 @@ class Agent:
         break_nudges = 0      # times we escalated a stuck edit this turn
         readonly_streak = 0   # consecutive steps with substantive tools but no landed edit
         gate_nudges = 0       # times the investigation->edit gate fired this turn
+        explore_streak = 0    # consecutive bash steps since the last landed edit (counts
+                              # AFTER an edit too — investigation_gate can't; see
+                              # guardrails.explore_commit_gate)
+        explore_gate_fires = 0  # times the explore->commit gate fired this turn
         subagent_sigs = set() # (description, prompt) of sub-agents already spawned this turn
         truncation_nudges = 0  # times we pushed past a token-cap truncation this turn
         garble_nudges = 0  # malformed-tool-call re-nudges (own counter, so a step-0
@@ -2182,6 +2186,26 @@ class Agent:
                     log.info("INVESTIGATION-GATE at step %d (streak, no edit) -> nudge #%d",
                              step, gate_nudges)
                     self.messages.append({"role": "tool", "name": "edit", "content": gate})
+
+            # Convergence gate (Terminus-2 port): count exploratory-bash steps since the
+            # last landed edit — unlike readonly_streak/investigation_gate this keeps
+            # counting AFTER an edit lands, which is where the demonstrated thrash lives
+            # (write early, then probe 60 more times without calling done). A NEW edit
+            # this step resets it; a bash-only step advances it.
+            if made_edit and not _gov_prev_made:
+                explore_streak = 0
+            elif any(n == "bash" for n, _ in calls):
+                explore_streak += 1
+            if not read_only_intent:
+                commit = guardrails.explore_commit_gate(
+                    explore_streak, made_edit, explore_gate_fires)
+                if commit:
+                    explore_gate_fires += 1
+                    explore_streak = 0
+                    log.info("EXPLORE-COMMIT gate at step %d (bash-streak, no change) "
+                             "-> nudge #%d", step, explore_gate_fires)
+                    self.messages.append(
+                        {"role": "tool", "name": "bash", "content": commit})
 
             # Break a flailing-probe run (e.g. guessing the test runner, repeated
             # `python -c import` checks) that the exact-call loop guard can't see because

--- a/src/chad/agent.py
+++ b/src/chad/agent.py
@@ -864,8 +864,8 @@ class Agent:
         gate_nudges = 0       # times the investigation->edit gate fired this turn
         explore_streak = 0    # consecutive bash steps since the last landed edit (counts
                               # AFTER an edit too — investigation_gate can't; see
-                              # guardrails.explore_commit_gate)
-        explore_gate_fires = 0  # times the explore->commit gate fired this turn
+                              # guardrails.verification_matrix)
+        explore_gate_fires = 0  # times the verification-matrix gate fired this turn
         subagent_sigs = set() # (description, prompt) of sub-agents already spawned this turn
         truncation_nudges = 0  # times we pushed past a token-cap truncation this turn
         garble_nudges = 0  # malformed-tool-call re-nudges (own counter, so a step-0
@@ -2187,25 +2187,28 @@ class Agent:
                              step, gate_nudges)
                     self.messages.append({"role": "tool", "name": "edit", "content": gate})
 
-            # Convergence gate (Terminus-2 port): count exploratory-bash steps since the
-            # last landed edit — unlike readonly_streak/investigation_gate this keeps
-            # counting AFTER an edit lands, which is where the demonstrated thrash lives
-            # (write early, then probe 60 more times without calling done). A NEW edit
-            # this step resets it; a bash-only step advances it.
+            # Convergence gate (verification-matrix design): count exploratory-
+            # bash steps since the last landed edit — unlike readonly_streak/
+            # investigation_gate this keeps counting AFTER an edit lands, which is where
+            # the demonstrated thrash lives (write early, then probe 60 more times
+            # without calling done). A NEW edit this step resets it; a bash-only step
+            # advances it. When it bites, the model gets the task's real requirements as
+            # a matrix to close by evidence-or-unverified, not an open-ended "keep going".
             if made_edit and not _gov_prev_made:
                 explore_streak = 0
             elif any(n == "bash" for n, _ in calls):
                 explore_streak += 1
             if not read_only_intent:
-                commit = guardrails.explore_commit_gate(
+                matrix = guardrails.verification_matrix(
+                    guardrails.audit_task_text(user_text),
                     explore_streak, made_edit, explore_gate_fires)
-                if commit:
+                if matrix:
                     explore_gate_fires += 1
                     explore_streak = 0
-                    log.info("EXPLORE-COMMIT gate at step %d (bash-streak, no change) "
-                             "-> nudge #%d", step, explore_gate_fires)
+                    log.info("VERIFICATION-MATRIX gate at step %d (bash-streak, no "
+                             "change) -> nudge #%d", step, explore_gate_fires)
                     self.messages.append(
-                        {"role": "tool", "name": "bash", "content": commit})
+                        {"role": "tool", "name": "bash", "content": matrix})
 
             # Break a flailing-probe run (e.g. guessing the test runner, repeated
             # `python -c import` checks) that the exact-call loop guard can't see because

--- a/src/chad/agent.py
+++ b/src/chad/agent.py
@@ -337,7 +337,7 @@ class Agent:
                  ctx_limit: int = 24000, mode: str = None, emit=None,
                  confirm=None, should_stop=None, drain_steering=None,
                  thinking: bool = True,
-                 max_gen_tokens: int = 8192, resume: list = None, persist: bool = False,
+                 max_gen_tokens: int = None, resume: list = None, persist: bool = False,
                  think_budget: int = None, think_ceiling: int = None,
                  turn_budget_tokens: int = None,
                  turn_budget_s: float = None, subagent: bool = False,
@@ -377,8 +377,21 @@ class Agent:
         # Per-step generation cap. The old 2048 default truncated legitimate work —
         # a reasoning turn that thinks, then emits a `write` of a whole test file can
         # exceed 2048 tokens, and the cut-off was being misread as a final answer
-        # (the "answers on paper then stops" bug). 8192 leaves room for think + a
-        # full-file write; truncation past it is now detected and nudged, not accepted.
+        # (the "answers on paper then stops" bug). 8192 fixed that but had its own
+        # loss class: on hard problems a long chain of thought can pin the cap while
+        # still inside <think>, so the step ends as discarded reasoning with no
+        # action and the next step re-derives from scratch — trace measurement shows
+        # these mid-think pins cluster on exactly the tasks that fail, and that an
+        # uncapped run of the same model almost never exceeds 8192 on its own
+        # (p99 ~4.7k) yet the rare 15-20k thought that does run long completes real
+        # work when allowed to finish. So the cap buys little in the common case and
+        # converts the long-thought tail into zero-progress dead steps. 32768 keeps
+        # a backstop against non-repetitive runaway garble (literal decode loops are
+        # the repeat guard's job, default ON) while fitting the longest observed
+        # legitimate thought with room for the action. Env knob for A/B without a
+        # code change (CHAD_* family).
+        if max_gen_tokens is None:
+            max_gen_tokens = config.env_int("CHAD_MAX_GEN_TOKENS", 32768)
         self.max_gen_tokens = max_gen_tokens
         # Soft think-cap base. None => the mechanism is OFF and generation is
         # byte-identical to before. Falls back to the CHAD_THINK_BUDGET env knob so the
@@ -1105,7 +1118,7 @@ class Agent:
                     return n >= _cap and "</think>" not in text_so_far
 
             # Degenerate-repetition stop (default ON): greedy decode can lock into
-            # repeating one short string until the 8192-token cap — ~4 minutes of dead
+            # repeating one short string until the max_gen_tokens cap — minutes of dead
             # generation per occurrence at 9B decode speed. Checked every 16 tokens on
             # the generation's tail; a hit stops the step (rep_fired tells this stopper
             # apart from the think-cap, which shares stats.stop_condition_fired) and the
@@ -1368,7 +1381,7 @@ class Agent:
                     # inside <think> — a distinct sub-bucket from a THINK-CAP/ceiling stop
                     # (those are agent-side stop_conditions; this is max_gen_tokens itself),
                     # so future autopsies can size it directly instead of inferring from
-                    # max_gen==8192. A salvaged step already injected the closing tag, so
+                    # the max_gen value. A salvaged step already injected the closing tag, so
                     # this is naturally False for it.
                     "reasoning_length_stop": hit_cap and "</think>" not in text,
                     "deadline_abort": deadline_fired[0],  # 103: wall-clock hard wrap-up cut

--- a/src/chad/guardrails.py
+++ b/src/chad/guardrails.py
@@ -782,44 +782,65 @@ def investigation_gate(readonly_streak, made_edit, gate_nudges, threshold=6):
             "verify it. If you already know the fix, apply it this step.]")
 
 
-def explore_commit_gate(explore_streak, made_edit, gate_fires,
+def verification_matrix(task_text, explore_streak, made_edit, gate_fires,
                         threshold=8, cap=6):
-    """Push a thrashing turn to converge — assess, then commit or finish.
+    """Pull a thrashing turn into a bounded verification phase.
 
-    The demonstrated failure (BARE89 vs Terminus-2, same model/box): chad's #1 loss
-    class is not wrong answers, it is non-convergence. 69% of failing trials never
-    called `done` — they ran a long tail of successful, exploratory bash (median 39
-    commands vs 12 on passes) with the SAME two edits a passing trial makes, and the
-    step cap killed them mid-poke. On break-filter the failing trial ran 72 bash
-    probes / 2 writes across 75 steps while chad's OWN passing trial found the
-    identical exploit in 13; the model knows the answer and researches past the
-    budget. Terminus, on the same weights, sits at chad's PASSING step count because
-    every turn it must state "what's been accomplished / what still needs doing" and
-    `task_complete` is a standing, one-bounce-guarded option — so it commits.
+    The demonstrated failure (measured on the bare full-89 run against a reference
+    harness on the same model/box): chad's #1 loss class is not wrong answers, it is
+    non-convergence. 69% of failing trials never called `done` — they ran a long tail
+    of successful, exploratory bash (median 39 commands vs 12 on passes) with the SAME
+    two edits a passing trial makes, and the step cap killed them mid-poke. On
+    break-filter the failing trial ran 72 bash probes / 2 writes across 75 steps while
+    chad's OWN passing trial found the identical exploit in 13; the model knows the
+    answer and researches past the budget. A reference harness on the same weights
+    sits at chad's PASSING step count.
 
-    `investigation_gate` above cannot cover this: it freezes the moment ANY edit
-    lands (its `not made_edit` guard), and break-filter's thrash is entirely AFTER
-    the first write. This gate counts exploratory-bash steps regardless of a prior
-    edit and re-arms (cap firings, not a hard 2), mirroring terminus's per-turn
-    reflection. It steers to VERIFY-then-`done` (never a bare "call done") so it
-    attacks the ran-out bucket without inflating done-but-wrong. Returns nudge text
-    or None; caller resets the streak so the next firing is `threshold` steps later."""
-    if not levers.enabled("explore_commit_gate"):
+    The design ported here reframes completion as a VERIFICATION MATRIX: every
+    requirement the task states must be closed by ONE of (a) causal evidence from a
+    real run through the public path, or (b) an explicit "unverified" note. That
+    single rule both BOUNDS the loop (a finite checklist has a terminal state, so the
+    turn knows when to stop) and blocks false-done (a row is not filled by a
+    self-authored PASS label, a snapshot, "no error", or an oracle built from the same
+    assumption as the code). The honest-unverified escape is load-bearing: it lets a
+    turn finish a genuinely-unverifiable requirement instead of thrashing on it
+    forever.
+
+    Reuses chad's own requirement extractor (`audit_requirement_lines`, the same engine
+    `done_audit` runs) so the matrix rows are the task's real predicates, not a
+    paraphrase. Fires from the THRASH entry point — the exploratory-bash streak — which
+    `done_audit` cannot reach (a ran-out turn never calls `done`) and `investigation_
+    gate` cannot reach (it freezes the moment any edit lands; this thrash is all
+    post-edit). Re-arms up to `cap`, never bare-"call done" (so it will not inflate the
+    done-but-wrong bucket that `done_audit` still guards at the actual `done`). Returns
+    nudge text or None; caller resets the streak after a firing."""
+    if not levers.enabled("verification_matrix"):
         return None
     if explore_streak < threshold or gate_fires >= cap:
         return None
-    levers.fired("explore_commit_gate", streak=explore_streak,
-                 made_edit=made_edit, fires=gate_fires)
-    have = ("Your solution may already be in place. " if made_edit
-            else "You have enough context to act now. ")
-    return (f"[you've run ~{explore_streak} commands since your last change without "
-            f"finishing the task. Stop and take stock: (1) what does the task "
-            f"actually require, and (2) what have you already done toward it? "
-            f"{have}If it's in place, STOP exploring — run the task's real "
-            f"verification (its test/check command) ONE time, and if it passes call "
-            f"`done`. If something is still missing, name the single remaining change "
-            f"in one sentence and make it now with edit/write. Do not run more "
-            f"exploratory probes.]")
+    req_lines = audit_requirement_lines(task_text, audit_extract_paths(task_text))
+    levers.fired("verification_matrix", streak=explore_streak,
+                 reqs=len(req_lines), made_edit=made_edit, fires=gate_fires)
+    parts = [
+        f"[you've run ~{explore_streak} commands since your last change without "
+        "finishing. Stop exploring and close this out as a verification matrix. The "
+        "hidden grader checks the task's OWN requirements — for EACH one below, you "
+        "need exactly ONE of two things:",
+        "  (a) EVIDENCE: a real run through the actual public path that shows the "
+        "required outcome. A snapshot, your own \"PASS\"/\"OK\" text, \"no error\", or "
+        "a check you built from the same assumption as the code do NOT count.",
+        "  (b) UNVERIFIED: a plain note that you could not verify it. An honest "
+        "\"unverified\" is allowed and lets you finish; a false \"it works\" is not.",
+    ]
+    if req_lines:
+        parts.append("Requirements from the task statement:")
+        parts += [f"  > {ln}" for ln in req_lines]
+    else:
+        parts.append("Re-read the task statement and list exactly what it requires, "
+                     "then close each item as (a) or (b).")
+    parts.append("When every requirement is (a) or (b), apply any fix still needed, "
+                 "then call `done`. Do not run more exploratory probes.]")
+    return "\n".join(parts)
 
 
 def edit_failed_to_land(result: str) -> bool:

--- a/src/chad/guardrails.py
+++ b/src/chad/guardrails.py
@@ -782,6 +782,46 @@ def investigation_gate(readonly_streak, made_edit, gate_nudges, threshold=6):
             "verify it. If you already know the fix, apply it this step.]")
 
 
+def explore_commit_gate(explore_streak, made_edit, gate_fires,
+                        threshold=8, cap=6):
+    """Push a thrashing turn to converge — assess, then commit or finish.
+
+    The demonstrated failure (BARE89 vs Terminus-2, same model/box): chad's #1 loss
+    class is not wrong answers, it is non-convergence. 69% of failing trials never
+    called `done` — they ran a long tail of successful, exploratory bash (median 39
+    commands vs 12 on passes) with the SAME two edits a passing trial makes, and the
+    step cap killed them mid-poke. On break-filter the failing trial ran 72 bash
+    probes / 2 writes across 75 steps while chad's OWN passing trial found the
+    identical exploit in 13; the model knows the answer and researches past the
+    budget. Terminus, on the same weights, sits at chad's PASSING step count because
+    every turn it must state "what's been accomplished / what still needs doing" and
+    `task_complete` is a standing, one-bounce-guarded option — so it commits.
+
+    `investigation_gate` above cannot cover this: it freezes the moment ANY edit
+    lands (its `not made_edit` guard), and break-filter's thrash is entirely AFTER
+    the first write. This gate counts exploratory-bash steps regardless of a prior
+    edit and re-arms (cap firings, not a hard 2), mirroring terminus's per-turn
+    reflection. It steers to VERIFY-then-`done` (never a bare "call done") so it
+    attacks the ran-out bucket without inflating done-but-wrong. Returns nudge text
+    or None; caller resets the streak so the next firing is `threshold` steps later."""
+    if not levers.enabled("explore_commit_gate"):
+        return None
+    if explore_streak < threshold or gate_fires >= cap:
+        return None
+    levers.fired("explore_commit_gate", streak=explore_streak,
+                 made_edit=made_edit, fires=gate_fires)
+    have = ("Your solution may already be in place. " if made_edit
+            else "You have enough context to act now. ")
+    return (f"[you've run ~{explore_streak} commands since your last change without "
+            f"finishing the task. Stop and take stock: (1) what does the task "
+            f"actually require, and (2) what have you already done toward it? "
+            f"{have}If it's in place, STOP exploring — run the task's real "
+            f"verification (its test/check command) ONE time, and if it passes call "
+            f"`done`. If something is still missing, name the single remaining change "
+            f"in one sentence and make it now with edit/write. Do not run more "
+            f"exploratory probes.]")
+
+
 def edit_failed_to_land(result: str) -> bool:
     """True when an edit/symbolic-edit tool result means the change did NOT apply — a
     no-op (old==new / replacement leaves file unchanged), an unmatched `old` string, or

--- a/src/chad/levers.py
+++ b/src/chad/levers.py
@@ -91,6 +91,13 @@ LEVERS: dict[str, Lever] = {
         "After ~6 read-only steps with no landed edit, steer the model to act before the "
         "step cap kills the turn with an empty patch.",
         "iter2"),
+    "explore_commit_gate": Lever(
+        "After ~8 exploratory-bash steps since the last change (even AFTER an edit has "
+        "landed — the case investigation_gate can't see), steer the turn to assess and "
+        "then verify-and-`done` or make the one remaining change. Ported from Terminus-2, "
+        "whose per-turn 'what's done / what remains' reflection keeps it at chad's passing "
+        "step count; targets the 69%-of-fails non-convergence (ran-out) bucket.",
+        "iter16"),
     "edit_loop_break": Lever(
         "After 2 consecutive edits that failed to land, stop the model re-trying "
         "variations and tell it to read the real lines / replace the whole symbol.",

--- a/src/chad/levers.py
+++ b/src/chad/levers.py
@@ -91,12 +91,13 @@ LEVERS: dict[str, Lever] = {
         "After ~6 read-only steps with no landed edit, steer the model to act before the "
         "step cap kills the turn with an empty patch.",
         "iter2"),
-    "explore_commit_gate": Lever(
+    "verification_matrix": Lever(
         "After ~8 exploratory-bash steps since the last change (even AFTER an edit has "
-        "landed — the case investigation_gate can't see), steer the turn to assess and "
-        "then verify-and-`done` or make the one remaining change. Ported from Terminus-2, "
-        "whose per-turn 'what's done / what remains' reflection keeps it at chad's passing "
-        "step count; targets the 69%-of-fails non-convergence (ran-out) bucket.",
+        "landed — the case investigation_gate can't see), pull the turn into a bounded "
+        "verification phase: for each task requirement, close it with a real causal run "
+        "OR an explicit 'unverified', then `done`. Reuses done_audit's requirement "
+        "extractor; targets the 69%-of-fails non-convergence (ran-out) bucket while the "
+        "honest-unverified escape keeps it from thrashing on the genuinely-unverifiable.",
         "iter16"),
     "edit_loop_break": Lever(
         "After 2 consecutive edits that failed to land, stop the model re-trying "

--- a/tests/test_agent_guards.py
+++ b/tests/test_agent_guards.py
@@ -885,26 +885,34 @@ def test_investigation_gate():
     check("gate bounded by gate_nudges", investigation_gate(20, made_edit=False, gate_nudges=2) is None)
 
 
-def test_explore_commit_gate():
-    from chad.guardrails import explore_commit_gate
+def test_verification_matrix():
+    from chad.guardrails import verification_matrix
+    task = (
+        "Write /app/out.html so it still triggers alert() after /app/filter.py runs.\n"
+        "The output must be valid HTML and must not require user interaction.\n")
     # Below threshold: silent.
-    check("no commit-gate below threshold",
-          explore_commit_gate(4, made_edit=False, gate_fires=0) is None)
-    # At/over threshold: fires and offers the verify-then-done exit.
-    g = explore_commit_gate(8, made_edit=False, gate_fires=0)
-    check("commit-gate fires at threshold", g is not None)
-    check("commit-gate steers to done", g is not None and "`done`" in g)
-    check("commit-gate demands verification first",
-          g is not None and "verification" in g)
+    check("no matrix below threshold",
+          verification_matrix(task, 4, made_edit=False, gate_fires=0) is None)
+    # At/over threshold: fires with the evidence-or-unverified matrix.
+    g = verification_matrix(task, 8, made_edit=False, gate_fires=0)
+    check("matrix fires at threshold", g is not None)
+    check("matrix offers the evidence path", g is not None and "EVIDENCE" in g)
+    check("matrix offers the honest-unverified escape",
+          g is not None and "UNVERIFIED" in g)
+    check("matrix ends at done", g is not None and "`done`" in g)
+    # Reuses the requirement extractor: the task's own predicate lines appear as rows.
+    check("matrix quotes a real requirement line",
+          g is not None and "out.html" in g)
     # The whole point vs investigation_gate: it STILL fires after an edit landed
     # (the break-filter thrash shape — write early, probe forever).
-    ge = explore_commit_gate(12, made_edit=True, gate_fires=0)
-    check("commit-gate fires even after an edit landed", ge is not None)
-    check("commit-gate acknowledges existing work",
-          ge is not None and "already be in place" in ge)
+    check("matrix fires even after an edit landed",
+          verification_matrix(task, 12, made_edit=True, gate_fires=0) is not None)
+    # A task with no extractable requirement lines still fires (generic close-out).
+    check("matrix fires with no extractable requirements",
+          verification_matrix("do the thing", 8, made_edit=False, gate_fires=0) is not None)
     # Re-armable but bounded by the firing cap.
-    check("commit-gate bounded by cap",
-          explore_commit_gate(30, made_edit=True, gate_fires=6) is None)
+    check("matrix bounded by cap",
+          verification_matrix(task, 30, made_edit=True, gate_fires=6) is None)
 
 
 def test_edit_failed_to_land():
@@ -1222,7 +1230,7 @@ if __name__ == "__main__":
     test_bash_result_verifies_ignores_trivial_checks()
     test_bash_result_verifies_requires_executing_command()
     test_investigation_gate()
-    test_explore_commit_gate()
+    test_verification_matrix()
     test_edit_failed_to_land()
     test_edit_loop_break()
     test_done_rejection()

--- a/tests/test_agent_guards.py
+++ b/tests/test_agent_guards.py
@@ -885,6 +885,28 @@ def test_investigation_gate():
     check("gate bounded by gate_nudges", investigation_gate(20, made_edit=False, gate_nudges=2) is None)
 
 
+def test_explore_commit_gate():
+    from chad.guardrails import explore_commit_gate
+    # Below threshold: silent.
+    check("no commit-gate below threshold",
+          explore_commit_gate(4, made_edit=False, gate_fires=0) is None)
+    # At/over threshold: fires and offers the verify-then-done exit.
+    g = explore_commit_gate(8, made_edit=False, gate_fires=0)
+    check("commit-gate fires at threshold", g is not None)
+    check("commit-gate steers to done", g is not None and "`done`" in g)
+    check("commit-gate demands verification first",
+          g is not None and "verification" in g)
+    # The whole point vs investigation_gate: it STILL fires after an edit landed
+    # (the break-filter thrash shape — write early, probe forever).
+    ge = explore_commit_gate(12, made_edit=True, gate_fires=0)
+    check("commit-gate fires even after an edit landed", ge is not None)
+    check("commit-gate acknowledges existing work",
+          ge is not None and "already be in place" in ge)
+    # Re-armable but bounded by the firing cap.
+    check("commit-gate bounded by cap",
+          explore_commit_gate(30, made_edit=True, gate_fires=6) is None)
+
+
 def test_edit_failed_to_land():
     check("no-op edit failed to land", edit_failed_to_land("[no-op edit: old and new are identical]"))
     check("not-found failed to land", edit_failed_to_land("[old string not found; no change made.]"))
@@ -1200,6 +1222,7 @@ if __name__ == "__main__":
     test_bash_result_verifies_ignores_trivial_checks()
     test_bash_result_verifies_requires_executing_command()
     test_investigation_gate()
+    test_explore_commit_gate()
     test_edit_failed_to_land()
     test_edit_loop_break()
     test_done_rejection()

--- a/tests/test_lever_bite.py
+++ b/tests/test_lever_bite.py
@@ -169,6 +169,14 @@ def test_investigation_gate(monkeypatch):
     assert guardrails.investigation_gate(8, made_edit=False, gate_nudges=0) is None
 
 
+def test_explore_commit_gate(monkeypatch):
+    n = bite("explore_commit_gate")
+    on(monkeypatch)
+    assert guardrails.explore_commit_gate(8, made_edit=True, gate_fires=0)
+    off(monkeypatch, n)
+    assert guardrails.explore_commit_gate(8, made_edit=True, gate_fires=0) is None
+
+
 def test_edit_loop_break(monkeypatch):
     n = bite("edit_loop_break")
     on(monkeypatch)

--- a/tests/test_lever_bite.py
+++ b/tests/test_lever_bite.py
@@ -169,12 +169,14 @@ def test_investigation_gate(monkeypatch):
     assert guardrails.investigation_gate(8, made_edit=False, gate_nudges=0) is None
 
 
-def test_explore_commit_gate(monkeypatch):
-    n = bite("explore_commit_gate")
+def test_verification_matrix(monkeypatch):
+    n = bite("verification_matrix")
     on(monkeypatch)
-    assert guardrails.explore_commit_gate(8, made_edit=True, gate_fires=0)
+    assert guardrails.verification_matrix("write /app/out.txt", 8,
+                                          made_edit=True, gate_fires=0)
     off(monkeypatch, n)
-    assert guardrails.explore_commit_gate(8, made_edit=True, gate_fires=0) is None
+    assert guardrails.verification_matrix("write /app/out.txt", 8,
+                                          made_edit=True, gate_fires=0) is None
 
 
 def test_edit_loop_break(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,7 @@ wheels = [
 
 [[package]]
 name = "chad-code"
-version = "1.12.0"
+version = "1.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },


### PR DESCRIPTION
- **Per-step generation cap raised 8192 → 32768** (`CHAD_MAX_GEN_TOKENS`
  overrides it): 8192 fixed the old truncated-write bug but introduced its
  own loss class — on hard problems a long chain of thought can pin the cap
  while still inside `<think>`, so the step ends as discarded reasoning with
  no action and the next step re-derives from scratch. Trace measurement:
  2% of steps pinned the cap, 82% of those mid-think, and a failing trial
  was 2.75× more likely to contain one; an uncapped run of the same model
  almost never exceeds 8192 on its own (p99 ~4.7k), yet the rare long
  thought that does run completes real work when allowed to finish. The cap
  stays as a backstop against non-repetitive runaway garble — literal decode
  loops remain the repeat guard's job.
- **New lever: `verification_matrix` (default OFF).** After ~8 exploratory
  bash steps since the last landed change — *including after an edit has
  landed*, the case `investigation_gate` cannot see, since it freezes the
  moment any edit lands — the turn is pulled into a bounded verification
  phase. It receives the task's own requirement lines (reusing the same
  extractor `done_audit` runs, so the rows are the real predicates, not a
  paraphrase) and must close each by exactly one of: (a) causal evidence
  from a real run through the public path — a snapshot, a self-authored
  "PASS", "no error", or a check built from the same assumption as the code
  do not count — or (b) an explicit "unverified" note. That single rule both
  bounds the loop (a finite checklist has a terminal state) and blocks
  false-done; the honest-unverified escape is load-bearing, letting a turn
  finish a genuinely unverifiable requirement instead of thrashing on it.
  Re-arms up to 6 times per turn and never says a bare "call `done`", so
  `done_audit` still guards the actual completion. Targets the measured #1
  loss class: 69% of failing trials never called `done`, running a long tail
  of exploratory bash (median 39 commands vs 12 on passes) around the same
  edits a passing trial makes, until the step cap killed them.