### PR TITLE
chad 2.0.2 — keep a stray <think> from discarding the turn it appears in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Notable, user-visible changes.
 
+## [2.0.2] — 2026-08-27
+
+**Fix: a stray `<think>` no longer discards the turn it appears in.** A thinking turn is
+stored so that re-rendering it extends the live KV cache instead of re-prefilling the
+transcript. Two helpers held that invariant, and both assumed at most one, well-formed
+think block — so a model that wrote `<think>` *inside* its own reasoning defeated both at
+once: the block was never closed, the turn was stored raw and re-rendered with an
+injected empty block (diverging from the cache at the turn's first token), and the
+reasoning before the stray tag was dropped from the transcript entirely.
+
+Now only the closing tag decides whether a block is open, and only a *leading* `<think>`
+is treated as a delimiter — any later tag is reasoning the model wrote, not structure.
+Measured on the Qwen3.8 template, a stray-tag turn re-prefilled 1146 tokens before the
+fix and 22 after, with the dropped reasoning restored.
+
 ## [2.0.1] — 2026-08-23
 
 **Hotfix: pin mlx to 0.32.0.** mlx 0.32.1 (released after 2.0.0) produces degenerate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # import name, and command name are independent. `uvx chad-code` runs the alias
 # script added under [project.scripts].
 name = "chad-code"
-version = "2.0.1"
+version = "2.0.2"
 description = "Claude-Code-style coding agent that runs entirely on a 24 GB Apple Silicon Mac (MLX, Qwen3.8-27B)"
 readme = "README.md"
 license = "MIT"

--- a/src/chad/__init__.py
+++ b/src/chad/__init__.py
@@ -4,7 +4,7 @@ A flat collection of cooperating modules behind one console script (``chad``):
 the inference engine, the tool layer, the agent loop, and the terminal UI.
 """
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 # chad sets no MLX_* runtime vars. MLX_METAL_FAST_SYNCH, MLX_MAX_OPS_PER_BUFFER
 # and MLX_MAX_MB_PER_BUFFER were each measured end-to-end on the 35B and every

--- a/src/chad/agent.py
+++ b/src/chad/agent.py
@@ -206,8 +206,15 @@ def close_unclosed_think(text: str, thinking: bool) -> str:
     re-prefill of the whole transcript next step (measured: tens of thousands of tokens
     at large context). Appending the missing `</think>` keeps the cached tokens a strict
     prefix of the re-render, so only a couple of tokens prefill instead. No-op when
-    thinking is off or the block is already closed."""
-    if thinking and "<think>" not in text and "</think>" not in text and text:
+    thinking is off or the block is already closed.
+
+    Only the CLOSE decides this. An earlier guard also required no `<think>` in the
+    text, which read a stray opening tag — one the model wrote inside its own reasoning,
+    not the template's — as "already a block" and skipped the append. That turn then
+    reached `split_inline_reasoning` with no `</think>` to split on, so it was stored raw
+    and re-rendered with an injected empty think block: the exact full re-prefill this
+    function exists to prevent, on the longest turns, where it costs the most."""
+    if thinking and "</think>" not in text and text:
         return text + "\n</think>"
     return text
 
@@ -237,8 +244,17 @@ def split_inline_reasoning(m: dict) -> dict:
     if m.get("role") != "assistant" or "</think>" not in content:
         return m
     head, _, tail = content.partition("</think>")
+    head = head.rstrip("\n")
+    # Strip a LEADING `<think>` only. The generation prompt already opened the block, so
+    # any later tag is reasoning the model wrote, not a delimiter. Taking the LAST one
+    # (`split("<think>")[-1]`) silently dropped every reasoning token before a stray tag:
+    # transcript content lost, and the shortened re-render diverges from the cache right
+    # where the turn began.
+    unwrapped = head.lstrip()
+    if unwrapped.startswith("<think>"):
+        head = unwrapped[len("<think>"):]
     return {**m,
-            "reasoning_content": head.rstrip("\n").split("<think>")[-1].lstrip("\n"),
+            "reasoning_content": head.lstrip("\n"),
             "content": tail.lstrip("\n")}
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -99,9 +99,15 @@ def test_close_unclosed_think():
     check("closed think untouched", close_unclosed_think(closed, True) == closed)
     # Thinking disabled (--no-think) -> never inject a tag.
     check("no-think untouched", close_unclosed_think("plain answer", False) == "plain answer")
-    # An explicit opening <think> in the text -> leave it (conservative; don't double-handle).
-    check("explicit <think> untouched",
-          close_unclosed_think("<think>partial", True) == "<think>partial")
+    # A stray opening <think> the model wrote INSIDE its own reasoning does not close
+    # anything. Only `</think>` decides. Reading the stray tag as "already handled" left
+    # the turn unclosed, which is the full re-prefill this helper exists to avoid.
+    check("stray <think>, no close -> closed",
+          close_unclosed_think("thinking <think> wait", True) == "thinking <think> wait\n</think>")
+    # ...and one that IS closed stays untouched, stray tag or not.
+    stray_closed = "thinking <think> wait</think>answer"
+    check("stray <think>, already closed -> untouched",
+          close_unclosed_think(stray_closed, True) == stray_closed)
     # Empty text -> no spurious tag.
     check("empty untouched", close_unclosed_think("", True) == "")
 
@@ -128,6 +134,14 @@ def test_split_inline_reasoning():
     check("tool turn untouched", split_inline_reasoning(tool) is tool)
     check("user turn untouched",
           split_inline_reasoning({"role": "user", "content": "a</think>b"})["content"] == "a</think>b")
+    # A stray <think> mid-reasoning is reasoning text, not a delimiter. Splitting on the
+    # LAST tag discarded everything before it — reasoning the model really emitted, gone
+    # from the transcript, and the shortened re-render no longer extends the KV cache.
+    out = split_inline_reasoning(
+        {"role": "assistant", "content": "first half <think> second half\n</think>\n\nans"})
+    check("stray tag keeps whole reasoning",
+          out["reasoning_content"] == "first half <think> second half", out)
+    check("stray tag keeps action", out["content"] == "ans", out)
 
 
 def test_reasoning_split_probe_classifies_templates():
@@ -181,6 +195,55 @@ def test_reasoning_split_probe_classifies_templates():
     check("unprobeable template -> off", a._reasoning_split_supported() is False)
 
 
+def test_stored_turn_extends_the_kv_cache():
+    """The invariant the two helpers exist to hold: whatever the model generated, the
+    NEXT render must begin with the bytes already in the KV cache.
+
+    Break it and the server re-evaluates the whole turn it just produced — the longer
+    the reasoning, the more it costs. Testing the property rather than each helper is
+    what catches a turn shape neither of them was written for; the shapes below are all
+    ones a real 27B emits. Model-free: `render` is a stand-in for Qwen3.8's template,
+    which reads `reasoning_content` and does NOT recover inline `</think>` itself.
+    """
+    def render(msgs):
+        out = []
+        for m in msgs:
+            role = m["role"]
+            if role == "assistant":
+                out.append("<|im_start|>assistant\n<think>\n"
+                           + (m.get("reasoning_content") or "")
+                           + "\n</think>\n\n" + (m.get("content") or "") + "<|im_end|>\n")
+            else:
+                out.append(f"<|im_start|>{role}\n{m.get('content') or ''}<|im_end|>\n")
+        # The generation prompt auto-opens the think block, so the turn continues inside it.
+        return "".join(out) + "<|im_start|>assistant\n<think>\n"
+
+    prefix = [{"role": "system", "content": "SYS"}, {"role": "user", "content": "task"}]
+    reasoning = "weighing the ragged-row rule " * 8
+    call = "<tool_call>\n<function=bash>\n</function>\n</tool_call>"
+
+    shapes = {
+        "normal turn": reasoning + "\n</think>\n\nrunning it." + call,
+        "cut off mid-think": reasoning,
+        "stray <think>, never closed": reasoning + "<think> wait " + reasoning,
+        "stray <think>, then closed": (reasoning + "<think> wait " + reasoning
+                                       + "\n</think>\n\nrunning it." + call),
+    }
+    for name, generated in shapes.items():
+        # What the server holds after decoding this turn: the prompt it was given, then
+        # the raw bytes it emitted.
+        cached = render(prefix) + generated
+        # What chad sends next, once the turn is stored and a tool result appended.
+        stored = {"role": "assistant", "content": close_unclosed_think(generated, True)}
+        nxt = render([split_inline_reasoning(m) for m in
+                      prefix + [stored, {"role": "tool", "name": "bash", "content": "ok"}]])
+        keep = len(os.path.commonprefix([cached, nxt]))
+        check(f"{name}: render extends the cache",
+              keep >= len(cached) - len("\n"), f"diverged after {keep} of {len(cached)} chars")
+        # Reasoning the model emitted must survive into the transcript, all of it.
+        check(f"{name}: reasoning kept",
+              reasoning.strip() in split_inline_reasoning(stored).get("reasoning_content", ""))
+
 if __name__ == "__main__":
     with pytest.MonkeyPatch.context() as mp:
         with tempfile.TemporaryDirectory() as d:
@@ -198,6 +261,7 @@ if __name__ == "__main__":
     test_close_unclosed_think()
     test_split_inline_reasoning()
     test_reasoning_split_probe_classifies_templates()
+    test_stored_turn_extends_the_kv_cache()
     print(f"\n{PASS} passed, {FAIL} failed")
     raise SystemExit(1 if FAIL else 0)
 

--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,7 @@ wheels = [
 
 [[package]]
 name = "chad-code"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },


### PR DESCRIPTION
Patch release. One fix, plus the version bump.

## The bug

A thinking turn is stored so that re-rendering it extends the live KV cache instead of
re-prefilling the transcript. Two helpers hold that invariant, and both assumed at most
one, well-formed `<think>` block. A model that writes a stray `<think>` *inside* its own
reasoning defeated both at once:

- `close_unclosed_think` read the stray opening tag as "already a block" and skipped
  appending `</think>`.
- That left `split_inline_reasoning` with no `</think>` to split on, so the turn was
  stored raw and re-rendered with an injected empty think block — diverging from the
  cache at the first token the turn generated.
- Once the close was fixed, the other half bit: `split("<think>")[-1]` took the **last**
  tag, dropping every reasoning token before the stray one out of the transcript
  entirely.

The cost lands on the longest turns, where a full re-prefill is most expensive.

## The fix

- Only the **close** decides whether a block is open — `close_unclosed_think` no longer
  looks at `<think>` at all.
- Only a **leading** `<think>` is a delimiter. The generation prompt already opened the
  block, so any later tag is reasoning the model wrote, not structure.

Measured on the Qwen3.8 template, a stray-tag turn re-prefills **1146 tokens before and
22 after**; closed, **615 before and 52 after**, with the dropped reasoning restored.

## Test

The new test pins the *property* rather than either helper: for each turn shape a 27B
really emits, the next render must begin with the bytes already decoded. A shape neither
helper anticipated fails here instead of silently in the prefill column.

## Release

2.0.1 → 2.0.2 in `pyproject.toml`, `src/chad/__init__.py`, and `uv.lock`, with a
CHANGELOG entry. `uv lock --check` clean. No dependency, harness, or model changes.

Full suite green: 868 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
